### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/112/593/496/9/1125934969.geojson
+++ b/data/112/593/496/9/1125934969.geojson
@@ -620,6 +620,9 @@
     },
     "wof:country":"ME",
     "wof:created":1497296936,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"9cb23085ca446e87aabe47d820130f2f",
     "wof:hierarchy":[
         {
@@ -630,7 +633,7 @@
         }
     ],
     "wof:id":1125934969,
-    "wof:lastmodified":1566603341,
+    "wof:lastmodified":1582223327,
     "wof:name":"Podgorica",
     "wof:parent_id":85674689,
     "wof:placetype":"locality",

--- a/data/421/179/031/421179031.geojson
+++ b/data/421/179/031/421179031.geojson
@@ -754,6 +754,9 @@
     },
     "wof:country":"ME",
     "wof:created":1459009202,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b6d317f7b90ba77e27f59529de023bd4",
     "wof:hierarchy":[
         {
@@ -764,7 +767,7 @@
         }
     ],
     "wof:id":421179031,
-    "wof:lastmodified":1566603315,
+    "wof:lastmodified":1582223327,
     "wof:name":"Cetinje",
     "wof:parent_id":85674625,
     "wof:placetype":"locality",

--- a/data/856/326/67/85632667.geojson
+++ b/data/856/326/67/85632667.geojson
@@ -980,6 +980,10 @@
     },
     "wof:country":"ME",
     "wof:country_alpha3":"MNE",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"0cf02fccfbd08b42a61297f65b46bc82",
     "wof:hierarchy":[
         {
@@ -994,7 +998,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1566603179,
+    "wof:lastmodified":1582223323,
     "wof:name":"Montenegro",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/890/430/929/890430929.geojson
+++ b/data/890/430/929/890430929.geojson
@@ -71,6 +71,9 @@
     },
     "wof:country":"ME",
     "wof:created":1469051871,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7fd40ad5ae76c475f9706c2925ddcc7",
     "wof:hierarchy":[
         {
@@ -81,7 +84,7 @@
         }
     ],
     "wof:id":890430929,
-    "wof:lastmodified":1566603323,
+    "wof:lastmodified":1582223327,
     "wof:name":"Marovi\u0107i",
     "wof:parent_id":85674613,
     "wof:placetype":"locality",

--- a/data/890/431/003/890431003.geojson
+++ b/data/890/431/003/890431003.geojson
@@ -73,6 +73,9 @@
     },
     "wof:country":"ME",
     "wof:created":1469051874,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"32bb1bbc2ad6f7b306da49f7f936ff48",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":890431003,
-    "wof:lastmodified":1566603329,
+    "wof:lastmodified":1582223327,
     "wof:name":"Brda",
     "wof:parent_id":85674625,
     "wof:placetype":"locality",

--- a/data/890/444/571/890444571.geojson
+++ b/data/890/444/571/890444571.geojson
@@ -112,6 +112,9 @@
     },
     "wof:country":"ME",
     "wof:created":1469052474,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b049c09918f613f354901c1588b46229",
     "wof:hierarchy":[
         {
@@ -122,7 +125,7 @@
         }
     ],
     "wof:id":890444571,
-    "wof:lastmodified":1566603331,
+    "wof:lastmodified":1582223327,
     "wof:name":"Dobrota",
     "wof:parent_id":85674643,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.