### PR TITLE
me concordances, placetype local, and more

### DIFF
--- a/data/421/187/163/421187163.geojson
+++ b/data/421/187/163/421187163.geojson
@@ -96,7 +96,7 @@
         }
     ],
     "wof:id":421187163,
-    "wof:lastmodified":1694492291,
+    "wof:lastmodified":1695886968,
     "wof:name":"Malesia e Madhe",
     "wof:parent_id":85674689,
     "wof:placetype":"county",

--- a/data/421/204/573/421204573.geojson
+++ b/data/421/204/573/421204573.geojson
@@ -136,7 +136,7 @@
     },
     "wof:country":"ME",
     "wof:created":1459010191,
-    "wof:geomhash":"c9b0fa75ae14bc9338ffb76560f82087",
+    "wof:geomhash":"79b169f7323393c00066f07d91044b95",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -146,7 +146,7 @@
         }
     ],
     "wof:id":421204573,
-    "wof:lastmodified":1690939334,
+    "wof:lastmodified":1695886968,
     "wof:name":"Konavle",
     "wof:parent_id":85674639,
     "wof:placetype":"county",

--- a/data/856/326/67/85632667.geojson
+++ b/data/856/326/67/85632667.geojson
@@ -1149,6 +1149,7 @@
         "hasc:id":"ME",
         "icao:code":"YU",
         "ioc:id":"MGO",
+        "iso:code":"ME",
         "itu:id":"MNE",
         "m49:code":"499",
         "marc:id":"mo",
@@ -1161,6 +1162,7 @@
         "wd:id":"Q236",
         "wk:page":"Montenegro"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
     "wof:country_alpha3":"MNE",
     "wof:geom_alt":[
@@ -1182,7 +1184,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1694492264,
+    "wof:lastmodified":1695881377,
     "wof:name":"Montenegro",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/746/13/85674613.geojson
+++ b/data/856/746/13/85674613.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.062613,
-    "geom:area_square_m":573818837.252236,
+    "geom:area_square_m":573818487.105301,
     "geom:bbox":"18.922546,42.011467,19.369998,42.321939",
     "geom:latitude":42.1705,
     "geom:longitude":19.138384,
@@ -291,13 +291,15 @@
         "gn:id":3204508,
         "gp:id":29389244,
         "hasc:id":"ME.BA",
+        "iso:code":"ME-02",
         "iso:id":"ME-02",
         "qs_pg:id":1291644,
         "unlc:id":"ME-02",
         "wd:id":"Q2604068"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"22d6726b76290c58ededb1c706a0f3bd",
+    "wof:geomhash":"7d824a4ff54e517c9852625d176f4e2c",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939331,
+    "wof:lastmodified":1695884759,
     "wof:name":"Bar",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/17/85674617.geojson
+++ b/data/856/746/17/85674617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032217,
-    "geom:area_square_m":296088526.418901,
+    "geom:area_square_m":296088974.445135,
     "geom:bbox":"19.13795,41.852362,19.374869,42.106507",
     "geom:latitude":41.991348,
     "geom:longitude":19.275452,
@@ -388,13 +388,15 @@
         "gn:id":3188514,
         "gp:id":29389241,
         "hasc:id":"ME.UL",
+        "iso:code":"ME-20",
         "iso:id":"ME-20",
         "qs_pg:id":1291639,
         "unlc:id":"ME-20",
         "wd:id":"Q3305169"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"ccc60f689b4b1622943e53a7b2ea9765",
+    "wof:geomhash":"8b210fb71243a5712344c2a3c337037a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -409,7 +411,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939329,
+    "wof:lastmodified":1695884759,
     "wof:name":"Ulcinj",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/21/85674621.geojson
+++ b/data/856/746/21/85674621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013409,
-    "geom:area_square_m":122664097.02223,
+    "geom:area_square_m":122664299.889121,
     "geom:bbox":"18.784931,42.18327,19.000887,42.360025",
     "geom:latitude":42.282771,
     "geom:longitude":18.886633,
@@ -284,13 +284,15 @@
         "gn:id":3203104,
         "gp:id":29389243,
         "hasc:id":"ME.BU",
+        "iso:code":"ME-05",
         "iso:id":"ME-05",
         "qs_pg:id":903220,
         "unlc:id":"ME-05",
         "wd:id":"Q3739214"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"165732e9966d959d57c476ca0c3bf4ad",
+    "wof:geomhash":"369f7b18256b8f89ed194a1c62782331",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -305,7 +307,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939329,
+    "wof:lastmodified":1695884759,
     "wof:name":"Budva",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/25/85674625.geojson
+++ b/data/856/746/25/85674625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10593,
-    "geom:area_square_m":965825205.913529,
+    "geom:area_square_m":965825637.801136,
     "geom:bbox":"18.648299,42.283621,19.142584,42.718116",
     "geom:latitude":42.493192,
     "geom:longitude":18.883545,
@@ -274,13 +274,15 @@
         "gn:id":3202640,
         "gp:id":29389242,
         "hasc:id":"ME.CE",
+        "iso:code":"ME-06",
         "iso:id":"ME-06",
         "qs_pg:id":903219,
         "unlc:id":"ME-06",
         "wd:id":"Q3305075"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"802dc108dcb7effa05294cf52ad44756",
+    "wof:geomhash":"e6ae4abf8a1fa831eb17ec7013cb2132",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -295,7 +297,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939331,
+    "wof:lastmodified":1695884759,
     "wof:name":"Cetinje",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/33/85674633.geojson
+++ b/data/856/746/33/85674633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043378,
-    "geom:area_square_m":393165941.801643,
+    "geom:area_square_m":393166305.928878,
     "geom:bbox":"20.047593,42.742508,20.355171,42.973605",
     "geom:latitude":42.86041,
     "geom:longitude":20.190526,
@@ -245,13 +245,15 @@
         "gn:id":786233,
         "gp:id":29389229,
         "hasc:id":"ME.RO",
+        "iso:code":"ME-17",
         "iso:id":"ME-17",
         "qs_pg:id":986402,
         "unlc:id":"ME-17",
         "wd:id":"Q3296677"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"29a526d6f2a225bcfd7491b7292043bf",
+    "wof:geomhash":"258410a0207e540141d1970db920c36b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -266,7 +268,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939328,
+    "wof:lastmodified":1695884324,
     "wof:name":"Ro\u017eaje",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/35/85674635.geojson
+++ b/data/856/746/35/85674635.geojson
@@ -291,11 +291,13 @@
         "gn:id":3193227,
         "gp:id":29389239,
         "hasc:id":"ME.PA",
+        "iso:code":"AL-10",
         "iso:id":"AL-10",
         "qs_pg:id":1114751,
         "unlc:id":"ME-13",
         "wd:id":"Q4859821"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
     "wof:geomhash":"4d0e26cbfbe1a17dce326be3b2af5015",
     "wof:hierarchy":[
@@ -312,7 +314,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884759,
     "wof:name":"Plav",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/39/85674639.geojson
+++ b/data/856/746/39/85674639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026059,
-    "geom:area_square_m":237623242.44104,
+    "geom:area_square_m":237622591.317423,
     "geom:bbox":"18.436425,42.366278,18.66002,42.59849",
     "geom:latitude":42.484767,
     "geom:longitude":18.543427,
@@ -312,13 +312,15 @@
         "gn:id":3199393,
         "gp:id":29389246,
         "hasc:id":"ME.HN",
+        "iso:code":"ME-08",
         "iso:id":"ME-08",
         "qs_pg:id":903222,
         "unlc:id":"ME-08",
         "wd:id":"Q3317366"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"d3eb7dec4699d4de8dfecb39258473d7",
+    "wof:geomhash":"6b104e21db9d8cb8d3657faa93e9b368",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -333,7 +335,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939330,
+    "wof:lastmodified":1695884759,
     "wof:name":"Herceg Novi",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/43/85674643.geojson
+++ b/data/856/746/43/85674643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.032044,
-    "geom:area_square_m":292179419.338686,
+    "geom:area_square_m":292179720.040064,
     "geom:bbox":"18.506798,42.27147,18.793561,42.629336",
     "geom:latitude":42.489885,
     "geom:longitude":18.676214,
@@ -279,13 +279,15 @@
         "gn:id":3197537,
         "gp:id":29389240,
         "hasc:id":"ME.KT",
+        "iso:code":"ME-10",
         "iso:id":"ME-10",
         "qs_pg:id":1291630,
         "unlc:id":"ME-10",
         "wd:id":"Q4856305"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"2438dc29334ddf64a554003653f9999f",
+    "wof:geomhash":"2a3f97429ec5bde8c35dc27aed9e1be1",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939329,
+    "wof:lastmodified":1695884759,
     "wof:name":"Kotor",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/49/85674649.geojson
+++ b/data/856/746/49/85674649.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.036731,
-    "geom:area_square_m":333718607.872297,
+    "geom:area_square_m":333718501.349966,
     "geom:bbox":"19.628136,42.58893,19.90941,42.82643",
     "geom:latitude":42.71276,
     "geom:longitude":19.75613,
@@ -363,13 +363,15 @@
         "gn:id":3343959,
         "gp:id":29389233,
         "hasc:id":"ME.AN",
+        "iso:code":"ME-01",
         "iso:id":"ME-01",
         "qs_pg:id":1114750,
         "unlc:id":"ME-01",
         "wd:id":"Q2384773"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"53c8b248103c2bdbd57ecd908e59a69b",
+    "wof:geomhash":"ef8c514943b309a74e9e3eda9492ac0f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -384,7 +386,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939331,
+    "wof:lastmodified":1695884759,
     "wof:name":"Andrijevica",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/53/85674653.geojson
+++ b/data/856/746/53/85674653.geojson
@@ -282,10 +282,12 @@
         "gn:id":3199070,
         "gp:id":29389228,
         "hasc:id":"ME.BE",
+        "iso:code":"ME-03",
         "qs_pg:id":986401,
         "unlc:id":"ME-03",
         "wd:id":"Q4853794"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
     "wof:geomhash":"58f42694040ba5a91f84cb13bc681c2b",
     "wof:hierarchy":[
@@ -302,7 +304,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884759,
     "wof:name":"Berane",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/57/85674657.geojson
+++ b/data/856/746/57/85674657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086052,
-    "geom:area_square_m":777599993.347569,
+    "geom:area_square_m":777599704.770833,
     "geom:bbox":"19.459464,42.90751,20.056344,43.218815",
     "geom:latitude":43.046682,
     "geom:longitude":19.744876,
@@ -328,13 +328,15 @@
         "gn:id":3204173,
         "gp:id":29389227,
         "hasc:id":"ME.BP",
+        "iso:code":"ME-04",
         "iso:id":"ME-04",
         "qs_pg:id":986400,
         "unlc:id":"ME-04",
         "wd:id":"Q4086488"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"e14119ebfa573f1daf2e36eb6dbafddf",
+    "wof:geomhash":"14dfa558f3911c1cb3da1e3b972b77dd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -349,7 +351,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939327,
+    "wof:lastmodified":1695884759,
     "wof:name":"Bijelo Polje",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/61/85674661.geojson
+++ b/data/856/746/61/85674661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056216,
-    "geom:area_square_m":511625655.421474,
+    "geom:area_square_m":511625741.147978,
     "geom:bbox":"18.93717,42.487174,19.300972,42.759509",
     "geom:latitude":42.606563,
     "geom:longitude":19.121918,
@@ -278,14 +278,16 @@
         "gn:id":3202193,
         "gp:id":29389236,
         "hasc:id":"ME.DA",
+        "iso:code":"ME-07",
         "iso:id":"ME-07",
         "qs_pg:id":898960,
         "unlc:id":"ME-07",
         "wd:id":"Q3741507",
         "wk:page":"Danilovgrad Municipality"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"bdb9bfdb0e7b2d016ad713fce2e8937b",
+    "wof:geomhash":"9eb4ad00d5bde66ea09f1873cc268f0b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -300,7 +302,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939326,
+    "wof:lastmodified":1695884759,
     "wof:name":"Danilovgrad",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/67/85674667.geojson
+++ b/data/856/746/67/85674667.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094231,
-    "geom:area_square_m":854946696.172187,
+    "geom:area_square_m":854946651.137858,
     "geom:bbox":"19.199893,42.661918,19.678985,42.934486",
     "geom:latitude":42.798558,
     "geom:longitude":19.434126,
@@ -272,13 +272,15 @@
         "gn:id":3197895,
         "gp:id":29389235,
         "hasc:id":"ME.KL",
+        "iso:code":"ME-09",
         "iso:id":"ME-09",
         "qs_pg:id":1291611,
         "unlc:id":"ME-09",
         "wd:id":"Q3303233"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"04ec933bb1ee77e5b0b0ac6baf5fc7ba",
+    "wof:geomhash":"b5be4c980bb7f4d9c979b1a16f6ffddb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939328,
+    "wof:lastmodified":1695884324,
     "wof:name":"Kola\u0161in",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/69/85674669.geojson
+++ b/data/856/746/69/85674669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.041128,
-    "geom:area_square_m":372137074.768437,
+    "geom:area_square_m":372136918.757251,
     "geom:bbox":"19.331255,42.881646,19.698777,43.051352",
     "geom:latitude":42.967069,
     "geom:longitude":19.508207,
@@ -306,13 +306,15 @@
         "gn:id":3194925,
         "gp:id":29389232,
         "hasc:id":"ME.MK",
+        "iso:code":"ME-11",
         "iso:id":"ME-11",
         "qs_pg:id":214053,
         "unlc:id":"ME-11",
         "wd:id":"Q3299782"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"666ff57ed2364ff2e5cdc08de7202a7d",
+    "wof:geomhash":"09d16e477fca4a551551b3a3f50e90ae",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939328,
+    "wof:lastmodified":1695884759,
     "wof:name":"Mojkovac",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/73/85674673.geojson
+++ b/data/856/746/73/85674673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.226994,
-    "geom:area_square_m":2058163133.003446,
+    "geom:area_square_m":2058163769.12674,
     "geom:bbox":"18.433531,42.620215,19.218652,43.124578",
     "geom:latitude":42.838637,
     "geom:longitude":18.782589,
@@ -311,13 +311,15 @@
         "gn:id":3194493,
         "gp:id":29389238,
         "hasc:id":"ME.NK",
+        "iso:code":"ME-12",
         "iso:id":"ME-12",
         "qs_pg:id":214054,
         "unlc:id":"ME-12",
         "wd:id":"Q4865016"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"0df9da4b262138dbe2ee08bd5b8ea18b",
+    "wof:geomhash":"f7cdb5c1eef0d06428ae072e4d1afb90",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -332,7 +334,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939329,
+    "wof:lastmodified":1695884324,
     "wof:name":"Nik\u0161ic",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/77/85674677.geojson
+++ b/data/856/746/77/85674677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.097301,
-    "geom:area_square_m":877664263.800434,
+    "geom:area_square_m":877664299.554933,
     "geom:bbox":"18.621128,42.9334,19.025175,43.351903",
     "geom:latitude":43.157272,
     "geom:longitude":18.847141,
@@ -275,13 +275,15 @@
         "gn:id":3193129,
         "gp:id":29389230,
         "hasc:id":"ME.PU",
+        "iso:code":"ME-15",
         "iso:id":"ME-15",
         "qs_pg:id":897325,
         "unlc:id":"ME-15",
         "wd:id":"Q4864476"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"2cb499b900f24be956d47a47dfe23f2f",
+    "wof:geomhash":"f2e540cd34a161a491512bed013211ca",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -296,7 +298,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939330,
+    "wof:lastmodified":1695884324,
     "wof:name":"Plu\u017eine",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/85/85674685.geojson
+++ b/data/856/746/85/85674685.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.146989,
-    "geom:area_square_m":1322734058.982923,
+    "geom:area_square_m":1322733209.529279,
     "geom:bbox":"18.90513,43.045177,19.547845,43.547886",
     "geom:latitude":43.300935,
     "geom:longitude":19.243392,
@@ -375,13 +375,15 @@
         "gn:id":3193160,
         "gp:id":29389226,
         "hasc:id":"ME.PL",
+        "iso:code":"ME-14",
         "iso:id":"ME-14",
         "qs_pg:id":230652,
         "unlc:id":"ME-14",
         "wd:id":"Q3299950"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"e0d124962c54c9b1665de33d01538b8c",
+    "wof:geomhash":"31f2f19547cc39aee5fe713f625bb6c2",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -396,7 +398,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939331,
+    "wof:lastmodified":1695884759,
     "wof:name":"Pljevlja",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/89/85674689.geojson
+++ b/data/856/746/89/85674689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.157367,
-    "geom:area_square_m":1435088238.352985,
+    "geom:area_square_m":1435088192.99353,
     "geom:bbox":"18.95598,42.198047,19.658037,42.739071",
     "geom:latitude":42.481463,
     "geom:longitude":19.341779,
@@ -559,13 +559,15 @@
         "gn:id":3189077,
         "gp:id":29389237,
         "hasc:id":"ME.PG",
+        "iso:code":"ME-16",
         "iso:id":"ME-16",
         "qs_pg:id":1291612,
         "unlc:id":"ME-16",
         "wd:id":"Q3305250"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"44b8dd8ee4a023a39d7e37b88eae73d7",
+    "wof:geomhash":"e75d9e1123c28a9930604b25d102573f",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -580,7 +582,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939328,
+    "wof:lastmodified":1695884759,
     "wof:name":"Podgorica",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/93/85674693.geojson
+++ b/data/856/746/93/85674693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.003604,
-    "geom:area_square_m":32905846.722671,
+    "geom:area_square_m":32905439.481611,
     "geom:bbox":"18.644966,42.357577,18.73465,42.476746",
     "geom:latitude":42.415468,
     "geom:longitude":18.698279,
@@ -236,13 +236,15 @@
         "gn:id":3189071,
         "gp:id":29389245,
         "hasc:id":"ME.TI",
+        "iso:code":"ME-19",
         "iso:id":"ME-19",
         "qs_pg:id":903221,
         "unlc:id":"ME-19",
         "wd:id":"Q3738564"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"8dbd7b3b7c8c4797113df6d9ac07d96d",
+    "wof:geomhash":"35419f4ac04e225b1a4da1cd5c445d52",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -257,7 +259,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939328,
+    "wof:lastmodified":1695884759,
     "wof:name":"Tivat",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/746/95/85674695.geojson
+++ b/data/856/746/95/85674695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.060178,
-    "geom:area_square_m":544409024.678018,
+    "geom:area_square_m":544410026.26301,
     "geom:bbox":"18.930917,42.858935,19.372286,43.097886",
     "geom:latitude":42.977675,
     "geom:longitude":19.131992,
@@ -305,13 +305,15 @@
         "gn:id":3191221,
         "gp:id":29389234,
         "hasc:id":"ME.SA",
+        "iso:code":"ME-18",
         "iso:id":"ME-18",
         "qs_pg:id":962093,
         "unlc:id":"ME-18",
         "wd:id":"Q13365880"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"15164c2497b41f9d4e78305215fcf003",
+    "wof:geomhash":"cad8f8c28b92b39ac57b24c02f751b6e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939327,
+    "wof:lastmodified":1695884324,
     "wof:name":"\u0160avnik",
     "wof:parent_id":85632667,
     "wof:placetype":"region",

--- a/data/856/747/01/85674701.geojson
+++ b/data/856/747/01/85674701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.051107,
-    "geom:area_square_m":461293040.35733,
+    "geom:area_square_m":461293020.710334,
     "geom:bbox":"18.989506,42.990115,19.411146,43.296546",
     "geom:latitude":43.11778,
     "geom:longitude":19.177063,
@@ -275,13 +275,15 @@
         "gn:id":3186995,
         "gp:id":29389231,
         "hasc:id":"ME.ZA",
+        "iso:code":"ME-21",
         "iso:id":"ME-21",
         "qs_pg:id":897326,
         "unlc:id":"ME-21",
         "wd:id":"Q3304454"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"ME",
-    "wof:geomhash":"7a6fa90be05e787bc5dc4743a82323ae",
+    "wof:geomhash":"7806f3a6d326155f3d7ad5509e2225aa",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -296,7 +298,7 @@
     "wof:lang_x_spoken":[
         "srp"
     ],
-    "wof:lastmodified":1690939326,
+    "wof:lastmodified":1695884324,
     "wof:name":"\u017dabljak",
     "wof:parent_id":85632667,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.