### PR TITLE
Validate edtf string

### DIFF
--- a/data/856/326/67/85632667.geojson
+++ b/data/856/326/67/85632667.geojson
@@ -2,1207 +2,1208 @@
   "id": 85632667,
   "type": "Feature",
   "properties": {
-    "date:inception_lower":"2006-05-01",
-    "date:inception_upper":"2006-06-30",
-    "edtf:cessation":"uuuu",
-    "edtf:inception":"2006-05~/2006-06~",
-    "eurostat:coast_type":"1",
-    "eurostat:country_code":"ME",
-    "eurostat:level_code":"3",
-    "eurostat:mount_type":"4",
-    "eurostat:name_latin":"Crna Gora",
-    "eurostat:name_local":"\u0426\u0440\u043d\u0430 \u0413\u043e\u0440\u0430",
-    "eurostat:nuts_2021_id":"ME000",
-    "eurostat:nuts_2021_level_0":"ME",
-    "eurostat:nuts_2021_level_1":"ME0",
-    "eurostat:nuts_2021_level_2":"ME00",
-    "eurostat:nuts_2021_level_3":"ME000",
-    "eurostat:population":617683,
-    "eurostat:population_year":2022,
-    "eurostat:urban_type":"2",
-    "geom:area":1.530964,
-    "geom:area_square_m":13892805424.462435,
-    "geom:bbox":"18.43398,41.846345,20.352911,43.558743",
-    "geom:latitude":42.786412,
-    "geom:longitude":19.251705,
-    "gn:population":666730,
-    "iso:country":"ME",
-    "itu:country_code":[
-        "382"
-    ],
-    "label:eng_x_preferred_placetype":[
-        "country"
-    ],
-    "label:eng_x_preferred_shortcode":[
-        "ME"
-    ],
-    "lbl:latitude":42.782845,
-    "lbl:longitude":19.157424,
-    "lbl:max_zoom":8.0,
-    "lbl:min_zoom":4.0,
-    "mps:latitude":42.782845,
-    "mps:longitude":19.157424,
-    "mz:hierarchy_label":1,
-    "mz:is_current":1,
-    "mz:max_zoom":10.0,
-    "mz:min_zoom":5.0,
-    "name:abk_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u0430"
+    "date:inception_lower": "2006-05-01",
+    "date:inception_upper": "2006-06-30",
+    "edtf:cessation": "",
+    "edtf:inception": "2006-05-~01/2006-06-~30",
+    "eurostat:coast_type": "1",
+    "eurostat:country_code": "ME",
+    "eurostat:level_code": "3",
+    "eurostat:mount_type": "4",
+    "eurostat:name_latin": "Crna Gora",
+    "eurostat:name_local": "Црна Гора",
+    "eurostat:nuts_2021_id": "ME000",
+    "eurostat:nuts_2021_level_0": "ME",
+    "eurostat:nuts_2021_level_1": "ME0",
+    "eurostat:nuts_2021_level_2": "ME00",
+    "eurostat:nuts_2021_level_3": "ME000",
+    "eurostat:population": 617683,
+    "eurostat:population_year": 2022,
+    "eurostat:urban_type": "2",
+    "geom:area": 1.5309636628079966,
+    "geom:area_square_m": 13892805424.462435,
+    "geom:bbox": "18.433980,41.846345,20.352911,43.558743",
+    "geom:latitude": 42.78641161200789,
+    "geom:longitude": 19.251705225587035,
+    "gn:population": 666730,
+    "iso:country": "ME",
+    "itu:country_code": [
+      "382"
+    ],
+    "label:eng_x_preferred_placetype": [
+      "country"
+    ],
+    "label:eng_x_preferred_shortcode": [
+      "ME"
+    ],
+    "lbl:latitude": 42.782845,
+    "lbl:longitude": 19.157424,
+    "lbl:max_zoom": 8,
+    "lbl:min_zoom": 4,
+    "mps:latitude": 42.782845,
+    "mps:longitude": 19.157424,
+    "mz:hierarchy_label": 1,
+    "mz:is_current": 1,
+    "mz:max_zoom": 10,
+    "mz:min_zoom": 5,
+    "name:abk_x_preferred": [
+      "Черногориа"
     ],
-    "name:ace_x_preferred":[
-        "Mont\u00e9n\u00e8gr\u00f4"
+    "name:ace_x_preferred": [
+      "Monténègrô"
     ],
-    "name:ady_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u0435"
+    "name:ady_x_preferred": [
+      "Черногорие"
     ],
-    "name:afr_x_preferred":[
-        "Montenegro"
+    "name:afr_x_preferred": [
+      "Montenegro"
     ],
-    "name:aka_x_preferred":[
-        "Montenegro"
+    "name:aka_x_preferred": [
+      "Montenegro"
     ],
-    "name:als_x_preferred":[
-        "Montenegro"
+    "name:als_x_preferred": [
+      "Montenegro"
     ],
-    "name:amh_x_preferred":[
-        "\u121e\u1295\u1274\u1294\u130d\u122e"
+    "name:amh_x_preferred": [
+      "ሞንቴኔግሮ"
     ],
-    "name:amh_x_variant":[
-        "\u121e\u1295\u1270\u1294\u130d\u122e"
+    "name:amh_x_variant": [
+      "ሞንተኔግሮ"
     ],
-    "name:ami_x_preferred":[
-        "Montenegro"
+    "name:ami_x_preferred": [
+      "Montenegro"
     ],
-    "name:ang_x_preferred":[
-        "Sweartbeorg"
+    "name:ang_x_preferred": [
+      "Sweartbeorg"
     ],
-    "name:anp_x_preferred":[
-        "\u092e\u093e\u0901\u091f\u0947\u0928\u0940\u0917\u094d\u0930\u094b"
+    "name:anp_x_preferred": [
+      "माँटेनीग्रो"
     ],
-    "name:ara_x_preferred":[
-        "\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u0623\u0633\u0648\u062f"
+    "name:ara_x_preferred": [
+      "الجبل الأسود"
     ],
-    "name:arc_x_preferred":[
-        "\u071b\u0718\u072a\u0710 \u0710\u0718\u071f\u0721\u0710"
+    "name:arc_x_preferred": [
+      "ܛܘܪܐ ܐܘܟܡܐ"
     ],
-    "name:arg_x_preferred":[
-        "Montenegro"
+    "name:arg_x_preferred": [
+      "Montenegro"
     ],
-    "name:ary_x_preferred":[
-        "\u0645\u0648\u0646\u0637\u064a\u0646\u064a\u06ad\u0631\u0648"
+    "name:ary_x_preferred": [
+      "مونطينيڭرو"
     ],
-    "name:arz_x_preferred":[
-        "\u0645\u0648\u0646\u062a\u064a\u0646\u064a\u062c\u0631\u0648"
+    "name:arz_x_preferred": [
+      "مونتينيجرو"
     ],
-    "name:ast_x_preferred":[
-        "Montenegro"
+    "name:ast_x_preferred": [
+      "Montenegro"
     ],
-    "name:ast_x_variant":[
-        "Montenegru"
+    "name:ast_x_variant": [
+      "Montenegru"
     ],
-    "name:ava_x_preferred":[
-        "\u0427\u0406\u0435\u0433\u0406\u0435\u0440\u043c\u0435\u0433\u0406\u0435\u0440"
+    "name:ava_x_preferred": [
+      "ЧІегІермегІер"
     ],
-    "name:ava_x_variant":[
-        "\u0427\u0435\u044d\u0440\u0430\u0431 \u041c\u0435\u044d\u0440"
+    "name:ava_x_variant": [
+      "Чеэраб Меэр"
     ],
-    "name:avk_x_preferred":[
-        "Cernagora"
+    "name:avk_x_preferred": [
+      "Cernagora"
     ],
-    "name:azb_x_preferred":[
-        "\u0645\u0648\u0646\u062a\u06cc\u0646\u06cc\u0642\u0631\u0648"
+    "name:azb_x_preferred": [
+      "مونتینیقرو"
     ],
-    "name:aze_x_preferred":[
-        "Monteneqro"
+    "name:aze_x_preferred": [
+      "Monteneqro"
     ],
-    "name:aze_x_variant":[
-        "\u00c7ernoqoriya"
+    "name:aze_x_variant": [
+      "Çernoqoriya"
     ],
-    "name:bak_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:bak_x_preferred": [
+      "Черногория"
     ],
-    "name:ban_x_preferred":[
-        "Montenegro"
+    "name:ban_x_preferred": [
+      "Montenegro"
     ],
-    "name:bar_x_preferred":[
-        "Montenegro"
+    "name:bar_x_preferred": [
+      "Montenegro"
     ],
-    "name:bcl_x_preferred":[
-        "Montenegro"
+    "name:bcl_x_preferred": [
+      "Montenegro"
     ],
-    "name:bel_x_preferred":[
-        "\u0427\u0430\u0440\u043d\u0430\u0433\u043e\u0440\u044b\u044f"
+    "name:bel_x_preferred": [
+      "Чарнагорыя"
     ],
-    "name:ben_x_preferred":[
-        "\u09ae\u09a8\u09cd\u099f\u09bf\u09a8\u09bf\u0997\u09cd\u09b0\u09cb"
+    "name:ben_x_preferred": [
+      "মন্টিনিগ্রো"
     ],
-    "name:bho_x_preferred":[
-        "\u092e\u094b\u0902\u091f\u0940\u0928\u0940\u0917\u094d\u0930\u094b"
+    "name:bho_x_preferred": [
+      "मोंटीनीग्रो"
     ],
-    "name:bih_x_preferred":[
-        "\u092e\u094b\u0902\u091f\u0940\u0928\u0940\u0917\u094d\u0930\u094b"
+    "name:bih_x_preferred": [
+      "मोंटीनीग्रो"
     ],
-    "name:bis_x_preferred":[
-        "Montenegro"
+    "name:bis_x_preferred": [
+      "Montenegro"
     ],
-    "name:bod_x_preferred":[
-        "\u0f58\u0f7c\u0f53\u0f0b\u0f4a\u0f7a\u0f53\u0f72\u0f42\u0f0b\u0f62\u0f7c\u0f0d"
+    "name:bod_x_preferred": [
+      "མོན་ཊེནིག་རོ།"
     ],
-    "name:bos_x_preferred":[
-        "Crna Gora"
+    "name:bos_x_preferred": [
+      "Crna Gora"
     ],
-    "name:bpy_x_preferred":[
-        "\u09ae\u09a8\u09cd\u099f\u09bf\u09a8\u09bf\u0997\u09cd\u09b0\u09cb"
+    "name:bpy_x_preferred": [
+      "মন্টিনিগ্রো"
     ],
-    "name:bre_x_preferred":[
-        "Montenegro"
+    "name:bre_x_preferred": [
+      "Montenegro"
     ],
-    "name:bul_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u0430 \u0433\u043e\u0440\u0430"
+    "name:bul_x_preferred": [
+      "Черна гора"
     ],
-    "name:bxr_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438"
+    "name:bxr_x_preferred": [
+      "Черногори"
     ],
-    "name:bxr_x_variant":[
-        "\u041c\u043e\u043d\u0442\u0435\u043d\u0435\u0433\u0440\u043e"
+    "name:bxr_x_variant": [
+      "Монтенегро"
     ],
-    "name:cat_x_preferred":[
-        "Montenegro"
+    "name:cat_x_preferred": [
+      "Montenegro"
     ],
-    "name:cdo_x_preferred":[
-        "Montenegro"
+    "name:cdo_x_preferred": [
+      "Montenegro"
     ],
-    "name:ceb_x_preferred":[
-        "Montenegro"
+    "name:ceb_x_preferred": [
+      "Montenegro"
     ],
-    "name:ces_x_preferred":[
-        "\u010cern\u00e1 Hora"
+    "name:ces_x_preferred": [
+      "Černá Hora"
     ],
-    "name:che_x_preferred":[
-        "\u04c0\u0430\u044c\u0440\u0436\u0430\u043b\u0430\u043c\u0430\u043d\u0447\u043e\u044c"
+    "name:che_x_preferred": [
+      "Ӏаьржаламанчоь"
     ],
-    "name:che_x_variant":[
-        "\u04c0\u0430\u044c\u0440\u0436\u0430\u043b\u0430\u043c\u0430\u043d\u0445\u043e\u0439\u0447\u043e\u044c"
+    "name:che_x_variant": [
+      "Ӏаьржаламанхойчоь"
     ],
-    "name:chr_x_preferred":[
-        "\u13bc\u13c2\u13d4\u13c1\u13a6\u13b6"
+    "name:chr_x_preferred": [
+      "ᎼᏂᏔᏁᎦᎶ"
     ],
-    "name:chu_x_preferred":[
-        "\u0427\u0440\u044c\u043d\u0430 \u0413\u043e\u0440\u0430"
+    "name:chu_x_preferred": [
+      "Чрьна Гора"
     ],
-    "name:chv_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438"
+    "name:chv_x_preferred": [
+      "Черногори"
     ],
-    "name:ckb_x_preferred":[
-        "\u0645\u06c6\u0646\u062a\u06cc\u0646\u06cc\u06af\u0631\u06c6"
+    "name:ckb_x_preferred": [
+      "مۆنتینیگرۆ"
     ],
-    "name:cor_x_preferred":[
-        "Montenegro"
+    "name:cor_x_preferred": [
+      "Montenegro"
     ],
-    "name:cos_x_preferred":[
-        "Montenegru"
+    "name:cos_x_preferred": [
+      "Montenegru"
     ],
-    "name:crh_x_preferred":[
-        "Montenegro"
+    "name:crh_x_preferred": [
+      "Montenegro"
     ],
-    "name:csb_x_preferred":[
-        "Cz\u00f4rnog\u00f3ra"
+    "name:csb_x_preferred": [
+      "Czôrnogóra"
     ],
-    "name:cym_x_preferred":[
-        "Montenegro"
+    "name:cym_x_preferred": [
+      "Montenegro"
     ],
-    "name:dag_x_preferred":[
-        "Montenegro"
+    "name:dag_x_preferred": [
+      "Montenegro"
     ],
-    "name:dan_x_preferred":[
-        "Montenegro"
+    "name:dan_x_preferred": [
+      "Montenegro"
     ],
-    "name:deu_x_preferred":[
-        "Montenegro"
+    "name:deu_x_preferred": [
+      "Montenegro"
     ],
-    "name:diq_x_preferred":[
-        "Montenegro"
+    "name:diq_x_preferred": [
+      "Montenegro"
     ],
-    "name:div_x_preferred":[
-        "\u0789\u07ae\u0782\u07b0\u0793\u07ac\u0782\u07a9\u078e\u07aa\u0783\u07af"
+    "name:div_x_preferred": [
+      "މޮންޓެނީގުރޯ"
     ],
-    "name:dsb_x_preferred":[
-        "Carnog\u00f3rska"
+    "name:dsb_x_preferred": [
+      "Carnogórska"
     ],
-    "name:dty_x_preferred":[
-        "\u092e\u094b\u0928\u094d\u091f\u0947\u0928\u0947\u0917\u094d\u0930\u094b"
+    "name:dty_x_preferred": [
+      "मोन्टेनेग्रो"
     ],
-    "name:ell_x_preferred":[
-        "\u039c\u03b1\u03c5\u03c1\u03bf\u03b2\u03bf\u03cd\u03bd\u03b9\u03bf"
+    "name:ell_x_preferred": [
+      "Μαυροβούνιο"
     ],
-    "name:eml_x_preferred":[
-        "M\u00f2ntn\u00e9gar"
+    "name:eml_x_preferred": [
+      "Mòntnégar"
     ],
-    "name:eng_x_preferred":[
-        "Montenegro"
+    "name:eng_x_preferred": [
+      "Montenegro"
     ],
-    "name:eng_x_variant":[
-        "Former Yugoslav Republic of Montenegro",
-        "ME",
-        "MNE",
-        "Rep. Montenegro",
-        "Republic of Montenegro",
-        "Socialist Republic of Montenegro"
+    "name:eng_x_variant": [
+      "Former Yugoslav Republic of Montenegro",
+      "ME",
+      "MNE",
+      "Rep. Montenegro",
+      "Republic of Montenegro",
+      "Socialist Republic of Montenegro"
     ],
-    "name:epo_x_preferred":[
-        "Montenegro"
+    "name:epo_x_preferred": [
+      "Montenegro"
     ],
-    "name:est_x_preferred":[
-        "Montenegro"
+    "name:est_x_preferred": [
+      "Montenegro"
     ],
-    "name:eus_x_preferred":[
-        "Montenegro"
+    "name:eus_x_preferred": [
+      "Montenegro"
     ],
-    "name:ewe_x_preferred":[
-        "Montenegro"
+    "name:ewe_x_preferred": [
+      "Montenegro"
     ],
-    "name:ewe_x_variant":[
-        "Montenegro nutome"
+    "name:ewe_x_variant": [
+      "Montenegro nutome"
     ],
-    "name:ext_x_preferred":[
-        "Montenegru"
+    "name:ext_x_preferred": [
+      "Montenegru"
     ],
-    "name:fao_x_preferred":[
-        "Montenegro"
+    "name:fao_x_preferred": [
+      "Montenegro"
     ],
-    "name:fas_x_preferred":[
-        "\u0645\u0648\u0646\u062a\u0647\u200c\u0646\u06af\u0631\u0648"
+    "name:fas_x_preferred": [
+      "مونته‌نگرو"
     ],
-    "name:fin_x_preferred":[
-        "Montenegro"
+    "name:fin_x_preferred": [
+      "Montenegro"
     ],
-    "name:fra_x_preferred":[
-        "Mont\u00e9n\u00e9gro"
+    "name:fra_x_preferred": [
+      "Monténégro"
     ],
-    "name:fra_x_variant":[
-        "R\u00e9publique du Mont\u00e9n\u00e9gro"
+    "name:fra_x_variant": [
+      "République du Monténégro"
     ],
-    "name:frp_x_preferred":[
-        "Mont\u00e8n\u00e8gro"
+    "name:frp_x_preferred": [
+      "Montènègro"
     ],
-    "name:frr_x_preferred":[
-        "Montenegro"
+    "name:frr_x_preferred": [
+      "Montenegro"
     ],
-    "name:frr_x_variant":[
-        "Monteneegro"
+    "name:frr_x_variant": [
+      "Monteneegro"
     ],
-    "name:fry_x_preferred":[
-        "Montenegro"
+    "name:fry_x_preferred": [
+      "Montenegro"
     ],
-    "name:ful_x_preferred":[
-        "Montenegro"
+    "name:ful_x_preferred": [
+      "Montenegro"
     ],
-    "name:ful_x_variant":[
-        "Montenegoro"
+    "name:ful_x_variant": [
+      "Montenegoro"
     ],
-    "name:fur_x_preferred":[
-        "Montenegro"
+    "name:fur_x_preferred": [
+      "Montenegro"
     ],
-    "name:gag_x_preferred":[
-        "\u00c7ernogoriya"
+    "name:gag_x_preferred": [
+      "Çernogoriya"
     ],
-    "name:gcr_x_preferred":[
-        "Mont\u00e9n\u00e9gro"
+    "name:gcr_x_preferred": [
+      "Monténégro"
     ],
-    "name:gla_x_preferred":[
-        "Am Monadh Neagrach"
+    "name:gla_x_preferred": [
+      "Am Monadh Neagrach"
     ],
-    "name:gle_x_preferred":[
-        "Montain\u00e9agr\u00f3"
+    "name:gle_x_preferred": [
+      "Montainéagró"
     ],
-    "name:glg_x_preferred":[
-        "Montenegro"
+    "name:glg_x_preferred": [
+      "Montenegro"
     ],
-    "name:glv_x_preferred":[
-        "Montenegro"
+    "name:glv_x_preferred": [
+      "Montenegro"
     ],
-    "name:gom_x_preferred":[
-        "\u092e\u093e\u0901\u091f\u0947\u0928\u093f\u0917\u094d\u0930\u094b"
+    "name:gom_x_preferred": [
+      "माँटेनिग्रो"
     ],
-    "name:got_x_preferred":[
-        "\ud800\udf43\ud800\udf45\ud800\udf30\ud800\udf42\ud800\udf44\ud800\udf30\ud800\udf31\ud800\udf30\ud800\udf39\ud800\udf42\ud800\udf32\ud800\udf30\ud800\udf3b\ud800\udf30\ud800\udf3d\ud800\udf33"
+    "name:got_x_preferred": [
+      "𐍃𐍅𐌰𐍂𐍄𐌰𐌱𐌰𐌹𐍂𐌲𐌰𐌻𐌰𐌽𐌳"
     ],
-    "name:gpe_x_preferred":[
-        "Montenegro"
+    "name:gpe_x_preferred": [
+      "Montenegro"
     ],
-    "name:grn_x_preferred":[
-        "Monten\u00e9gyro"
+    "name:grn_x_preferred": [
+      "Montenégyro"
     ],
-    "name:gsw_x_preferred":[
-        "Montenegro"
+    "name:gsw_x_preferred": [
+      "Montenegro"
     ],
-    "name:guj_x_preferred":[
-        "\u0aae\u0acb\u0aa8\u0acd\u0a9f\u0ac7\u0aa8\u0ac0\u0a97\u0acd\u0ab0\u0acb"
+    "name:guj_x_preferred": [
+      "મોન્ટેનીગ્રો"
     ],
-    "name:guj_x_variant":[
-        "\u0aae\u0ac9\u0aa8\u0acd\u0a9f\u0ac7\u0a82\u0aa8\u0ac7\u0a97\u0acd\u0ab0\u0acb"
+    "name:guj_x_variant": [
+      "મૉન્ટેંનેગ્રો"
     ],
-    "name:hak_x_preferred":[
-        "Montenegro"
+    "name:hak_x_preferred": [
+      "Montenegro"
     ],
-    "name:hak_x_variant":[
-        "M\u00f9ng-thi\u030dt-nui-k\u00f4-l\u00f2"
+    "name:hak_x_variant": [
+      "Mùng-thi̍t-nui-kô-lò"
     ],
-    "name:hat_x_preferred":[
-        "Montenegwo"
+    "name:hat_x_preferred": [
+      "Montenegwo"
     ],
-    "name:hau_x_preferred":[
-        "Montenegro"
+    "name:hau_x_preferred": [
+      "Montenegro"
     ],
-    "name:haw_x_preferred":[
-        "Montenegero"
+    "name:haw_x_preferred": [
+      "Montenegero"
     ],
-    "name:hbs_x_preferred":[
-        "Crna Gora"
+    "name:hbs_x_preferred": [
+      "Crna Gora"
     ],
-    "name:heb_x_preferred":[
-        "\u05de\u05d5\u05e0\u05d8\u05e0\u05d2\u05e8\u05d5"
+    "name:heb_x_preferred": [
+      "מונטנגרו"
     ],
-    "name:hif_x_preferred":[
-        "Montenegro"
+    "name:hif_x_preferred": [
+      "Montenegro"
     ],
-    "name:hin_x_preferred":[
-        "\u092e\u0949\u0928\u094d\u091f\u0947\u0928\u0940\u0917\u094d\u0930\u094b"
+    "name:hin_x_preferred": [
+      "मॉन्टेनीग्रो"
     ],
-    "name:hin_x_variant":[
-        "\u092e\u094b\u0902\u091f\u0947\u0928\u0947\u0917\u094d\u0930\u094b"
+    "name:hin_x_variant": [
+      "मोंटेनेग्रो"
     ],
-    "name:hrv_x_preferred":[
-        "Crna Gora"
+    "name:hrv_x_preferred": [
+      "Crna Gora"
     ],
-    "name:hsb_x_preferred":[
-        "\u010corna Hora"
+    "name:hsb_x_preferred": [
+      "Čorna Hora"
     ],
-    "name:hun_x_preferred":[
-        "Montenegr\u00f3"
+    "name:hun_x_preferred": [
+      "Montenegró"
     ],
-    "name:hye_x_preferred":[
-        "\u0549\u0565\u057c\u0576\u0578\u0563\u0578\u0580\u056b\u0561"
+    "name:hye_x_preferred": [
+      "Չեռնոգորիա"
     ],
-    "name:hyw_x_preferred":[
-        "\u0544\u0578\u0576\u0569\u0565\u0576\u0565\u056f\u0580\u0585"
+    "name:hyw_x_preferred": [
+      "Մոնթենեկրօ"
     ],
-    "name:ido_x_preferred":[
-        "Montenegro"
+    "name:ido_x_preferred": [
+      "Montenegro"
     ],
-    "name:ile_x_preferred":[
-        "Montenegro"
+    "name:ile_x_preferred": [
+      "Montenegro"
     ],
-    "name:ilo_x_preferred":[
-        "Montenegro"
+    "name:ilo_x_preferred": [
+      "Montenegro"
     ],
-    "name:ina_x_preferred":[
-        "Montenegro"
+    "name:ina_x_preferred": [
+      "Montenegro"
     ],
-    "name:ind_x_preferred":[
-        "Montenegro"
+    "name:ind_x_preferred": [
+      "Montenegro"
     ],
-    "name:isl_x_preferred":[
-        "Svartfjallaland"
+    "name:isl_x_preferred": [
+      "Svartfjallaland"
     ],
-    "name:isl_x_variant":[
-        "Montenegro"
+    "name:isl_x_variant": [
+      "Montenegro"
     ],
-    "name:ita_x_preferred":[
-        "Montenegro"
+    "name:ita_x_preferred": [
+      "Montenegro"
     ],
-    "name:jam_x_preferred":[
-        "Montenegro"
+    "name:jam_x_preferred": [
+      "Montenegro"
     ],
-    "name:jav_x_preferred":[
-        "Monten\u00e9gro"
+    "name:jav_x_preferred": [
+      "Montenégro"
     ],
-    "name:jpn_x_preferred":[
-        "\u30e2\u30f3\u30c6\u30cd\u30b0\u30ed"
+    "name:jpn_x_preferred": [
+      "モンテネグロ"
     ],
-    "name:kaa_x_preferred":[
-        "Montenegro"
+    "name:kaa_x_preferred": [
+      "Montenegro"
     ],
-    "name:kaa_x_variant":[
-        "Shernogoriya"
+    "name:kaa_x_variant": [
+      "Shernogoriya"
     ],
-    "name:kab_x_preferred":[
-        "Adrar aberkan"
+    "name:kab_x_preferred": [
+      "Adrar aberkan"
     ],
-    "name:kal_x_preferred":[
-        "Montenegro"
+    "name:kal_x_preferred": [
+      "Montenegro"
     ],
-    "name:kan_x_preferred":[
-        "\u0cae\u0cbe\u0c82\u0c9f\u0cc6\u0ca8\u0cc6\u0c97\u0ccd\u0cb0\u0cca"
+    "name:kan_x_preferred": [
+      "ಮಾಂಟೆನೆಗ್ರೊ"
     ],
-    "name:kan_x_variant":[
-        "\u0cae\u0cca\u0c82\u0c9f\u0cc6\u0ca8\u0cc6\u0c97\u0ccd\u0cb0\u0ccb"
+    "name:kan_x_variant": [
+      "ಮೊಂಟೆನೆಗ್ರೋ"
     ],
-    "name:kat_x_preferred":[
-        "\u10db\u10dd\u10dc\u10e2\u10d4\u10dc\u10d4\u10d2\u10e0\u10dd"
+    "name:kat_x_preferred": [
+      "მონტენეგრო"
     ],
-    "name:kat_x_variant":[
-        "\u10e9\u10d4\u10e0\u10dc\u10dd\u10d2\u10dd\u10e0\u10d8\u10d0"
+    "name:kat_x_variant": [
+      "ჩერნოგორია"
     ],
-    "name:kaz_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:kaz_x_preferred": [
+      "Черногория"
     ],
-    "name:kbd_x_preferred":[
-        "\u0411\u0433\u044b\u0444\u04c0\u044b\u0446\u04c0\u0435\u0439"
+    "name:kbd_x_preferred": [
+      "БгыфӀыцӀей"
     ],
-    "name:kbd_x_variant":[
-        "\u041a\u044a\u0443\u0449\u0445\u044c\u044d\u0444\u04c0\u044b\u0446\u04c0\u044d"
+    "name:kbd_x_variant": [
+      "КъущхьэфӀыцӀэ"
     ],
-    "name:kin_x_preferred":[
-        "Montenegoro"
+    "name:kin_x_preferred": [
+      "Montenegoro"
     ],
-    "name:kir_x_preferred":[
-        "\u041c\u043e\u043d\u0442\u0435\u043d\u0435\u0433\u0440\u043e"
+    "name:kir_x_preferred": [
+      "Монтенегро"
     ],
-    "name:koi_x_preferred":[
-        "\u0426\u04e7\u0440\u043d\u0430\u0433\u043e\u0440\u0430"
+    "name:koi_x_preferred": [
+      "Цӧрнагора"
     ],
-    "name:kom_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:kom_x_preferred": [
+      "Черногория"
     ],
-    "name:kon_x_preferred":[
-        "Monte Negro"
+    "name:kon_x_preferred": [
+      "Monte Negro"
     ],
-    "name:kor_x_preferred":[
-        "\ubaac\ud14c\ub124\uadf8\ub85c"
+    "name:kor_x_preferred": [
+      "몬테네그로"
     ],
-    "name:krc_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:krc_x_preferred": [
+      "Черногория"
     ],
-    "name:kur_x_preferred":[
-        "Montenegro"
+    "name:kur_x_preferred": [
+      "Montenegro"
     ],
-    "name:kur_x_variant":[
-        "\u0645\u06c6\u0646\u062a\u06cc\u0646\u06cc\u06af\u0631\u06c6"
+    "name:kur_x_variant": [
+      "مۆنتینیگرۆ"
     ],
-    "name:lad_x_preferred":[
-        "Montenegro"
+    "name:lad_x_preferred": [
+      "Montenegro"
     ],
-    "name:lao_x_preferred":[
-        "\u0e9b\u0eb0\u0ec0\u0e97\u0e94\u0ea1\u0ebb\u0e87\u0ec0\u0e95\u0ec0\u0e99\u0ec2\u0e81"
+    "name:lao_x_preferred": [
+      "ປະເທດມົງເຕເນໂກ"
     ],
-    "name:lat_x_preferred":[
-        "Mons Niger"
+    "name:lat_x_preferred": [
+      "Mons Niger"
     ],
-    "name:lav_x_preferred":[
-        "Melnkalne"
+    "name:lav_x_preferred": [
+      "Melnkalne"
     ],
-    "name:lez_x_preferred":[
-        "\u0427I\u0443\u043b\u0430\u0432\u0441\u0443\u0432"
+    "name:lez_x_preferred": [
+      "ЧIулавсув"
     ],
-    "name:lez_x_variant":[
-        "\u0427\u04c0\u0443\u043b\u0430\u0432\u0441\u0443\u0432"
+    "name:lez_x_variant": [
+      "ЧӀулавсув"
     ],
-    "name:lfn_x_preferred":[
-        "Tsernagora"
+    "name:lfn_x_preferred": [
+      "Tsernagora"
     ],
-    "name:lij_x_preferred":[
-        "Monteneigro (Na\u00e7ioin d'Eur\u00f2pa)"
+    "name:lij_x_preferred": [
+      "Monteneigro (Naçioin d'Euròpa)"
     ],
-    "name:lij_x_variant":[
-        "Monteneigro",
-        "Monten\u00e9igro"
+    "name:lij_x_variant": [
+      "Monteneigro",
+      "Montenéigro"
     ],
-    "name:lim_x_preferred":[
-        "Montenegro"
+    "name:lim_x_preferred": [
+      "Montenegro"
     ],
-    "name:lin_x_preferred":[
-        "Montenegro"
+    "name:lin_x_preferred": [
+      "Montenegro"
     ],
-    "name:lit_x_preferred":[
-        "Juodkalnija"
+    "name:lit_x_preferred": [
+      "Juodkalnija"
     ],
-    "name:liv_x_preferred":[
-        "Montenegro"
+    "name:liv_x_preferred": [
+      "Montenegro"
     ],
-    "name:lld_x_preferred":[
-        "Montenegro"
+    "name:lld_x_preferred": [
+      "Montenegro"
     ],
-    "name:lmo_x_preferred":[
-        "Muntnegher"
+    "name:lmo_x_preferred": [
+      "Muntnegher"
     ],
-    "name:lrc_x_preferred":[
-        "\u0645\u0648\u0646\u062a\u0626\u0646\u0626\u06af\u0631\u0648"
+    "name:lrc_x_preferred": [
+      "مونتئنئگرو"
     ],
-    "name:ltg_x_preferred":[
-        "Malnkalneja"
+    "name:ltg_x_preferred": [
+      "Malnkalneja"
     ],
-    "name:ltz_x_preferred":[
-        "Montenegro"
+    "name:ltz_x_preferred": [
+      "Montenegro"
     ],
-    "name:lzh_x_preferred":[
-        "\u8499\u7279\u5167\u54e5\u7f85"
+    "name:lzh_x_preferred": [
+      "蒙特內哥羅"
     ],
-    "name:mad_x_preferred":[
-        "Montenegro"
+    "name:mad_x_preferred": [
+      "Montenegro"
     ],
-    "name:mal_x_preferred":[
-        "\u0d2e\u0d4a\u0d23\u0d4d\u0d1f\u0d3f\u0d28\u0d46\u0d17\u0d4d\u0d30\u0d4b"
+    "name:mal_x_preferred": [
+      "മൊണ്ടിനെഗ്രോ"
     ],
-    "name:mal_x_variant":[
-        "\u0d2e\u0d4b\u0d23\u0d4d\u0d1f\u0d47\u0d28\u0d47\u0d17\u0d4d\u0d30\u0d4b",
-        "\u0d2e\u0d4b\u0d23\u0d4d\u0d1f\u0d46\u0d28\u0d46\u0d17\u0d4d\u0d30\u0d4a"
+    "name:mal_x_variant": [
+      "മോണ്ടേനേഗ്രോ",
+      "മോണ്ടെനെഗ്രൊ"
     ],
-    "name:mar_x_preferred":[
-        "\u092e\u093e\u0901\u091f\u0947\u0928\u093f\u0917\u094d\u0930\u094b"
+    "name:mar_x_preferred": [
+      "माँटेनिग्रो"
     ],
-    "name:mar_x_variant":[
-        "\u092e\u094b\u0902\u091f\u0947\u0928\u0947\u0917\u094d\u0930\u094b"
+    "name:mar_x_variant": [
+      "मोंटेनेग्रो"
     ],
-    "name:mdf_x_preferred":[
-        "\u0420\u0430\u0432\u0436\u0430 \u041f\u0430\u043d\u0434\u0430"
+    "name:mdf_x_preferred": [
+      "Равжа Панда"
     ],
-    "name:mhr_x_preferred":[
-        "\u0428\u0435\u043c\u043a\u0443\u0440\u044b\u043a \u042d\u043b"
+    "name:mhr_x_preferred": [
+      "Шемкурык Эл"
     ],
-    "name:min_x_preferred":[
-        "Montenegro"
+    "name:min_x_preferred": [
+      "Montenegro"
     ],
-    "name:mkd_x_preferred":[
-        "\u0426\u0440\u043d\u0430 \u0413\u043e\u0440\u0430"
+    "name:mkd_x_preferred": [
+      "Црна Гора"
     ],
-    "name:mlg_x_preferred":[
-        "Montenegro"
+    "name:mlg_x_preferred": [
+      "Montenegro"
     ],
-    "name:mlt_x_preferred":[
-        "Montenegro"
+    "name:mlt_x_preferred": [
+      "Montenegro"
     ],
-    "name:mni_x_preferred":[
-        "\uabc3\uabe3\uabdf\uabc7\uabe6\uabc5\uabe6\uabd2\uabed\uabd4\uabe3"
+    "name:mni_x_preferred": [
+      "ꯃꯣꯟꯇꯦꯅꯦꯒ꯭ꯔꯣ"
     ],
-    "name:mon_x_preferred":[
-        "\u041c\u043e\u043d\u0442\u0435\u043d\u0435\u0433\u0440\u043e"
+    "name:mon_x_preferred": [
+      "Монтенегро"
     ],
-    "name:mri_x_preferred":[
-        "Montenegro"
+    "name:mri_x_preferred": [
+      "Montenegro"
     ],
-    "name:msa_x_preferred":[
-        "Montenegro"
+    "name:msa_x_preferred": [
+      "Montenegro"
     ],
-    "name:mya_x_preferred":[
-        "\u1019\u103d\u1014\u103a\u1010\u102e\u1014\u102e\u1002\u101b\u102d\u102f\u1038\u1014\u102d\u102f\u1004\u103a\u1004\u1036"
+    "name:mya_x_preferred": [
+      "မွန်တီနီဂရိုးနိုင်ငံ"
     ],
-    "name:mya_x_variant":[
-        "\u1019\u103d\u1014\u103a\u1010\u102e\u1014\u102d\u1002\u101b\u102d\u102f\u1038"
+    "name:mya_x_variant": [
+      "မွန်တီနိဂရိုး"
     ],
-    "name:myv_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f \u041c\u0430\u0441\u0442\u043e\u0440"
+    "name:myv_x_preferred": [
+      "Черногория Мастор"
     ],
-    "name:mzn_x_preferred":[
-        "\u0645\u0648\u0646\u062a\u0647 \u0646\u06af\u0631\u0648"
+    "name:mzn_x_preferred": [
+      "مونته نگرو"
     ],
-    "name:nah_x_preferred":[
-        "Tl\u012bltep\u0113c"
+    "name:nah_x_preferred": [
+      "Tlīltepēc"
     ],
-    "name:nan_x_preferred":[
-        "O\u0358-soa\u207f Ki\u014dng-h\u00f4-kok"
+    "name:nan_x_preferred": [
+      "O͘-soaⁿ Kiōng-hô-kok"
     ],
-    "name:nan_x_variant":[
-        "Montenegro"
+    "name:nan_x_variant": [
+      "Montenegro"
     ],
-    "name:nap_x_preferred":[
-        "Montenegro"
+    "name:nap_x_preferred": [
+      "Montenegro"
     ],
-    "name:nau_x_preferred":[
-        "Montenegro"
+    "name:nau_x_preferred": [
+      "Montenegro"
     ],
-    "name:nav_x_preferred":[
-        "Dzi\u0142izhin Bik\u00e9yah"
+    "name:nav_x_preferred": [
+      "Dziłizhin Bikéyah"
     ],
-    "name:nds_nld_x_preferred":[
-        "Montenegro"
+    "name:nds_nld_x_preferred": [
+      "Montenegro"
     ],
-    "name:nds_x_preferred":[
-        "Montenegro"
+    "name:nds_x_preferred": [
+      "Montenegro"
     ],
-    "name:nep_x_preferred":[
-        "\u092e\u094b\u0928\u094d\u091f\u0947\u0928\u0947\u0917\u094d\u0930\u094b"
+    "name:nep_x_preferred": [
+      "मोन्टेनेग्रो"
     ],
-    "name:nld_x_preferred":[
-        "Montenegro"
+    "name:nld_x_preferred": [
+      "Montenegro"
     ],
-    "name:nno_x_preferred":[
-        "Montenegro"
+    "name:nno_x_preferred": [
+      "Montenegro"
     ],
-    "name:nob_x_preferred":[
-        "Montenegro"
+    "name:nob_x_preferred": [
+      "Montenegro"
     ],
-    "name:nor_x_preferred":[
-        "Montenegro"
+    "name:nor_x_preferred": [
+      "Montenegro"
     ],
-    "name:nov_x_preferred":[
-        "Montenegro"
+    "name:nov_x_preferred": [
+      "Montenegro"
     ],
-    "name:nrm_x_preferred":[
-        "Crna Gora"
+    "name:nrm_x_preferred": [
+      "Crna Gora"
     ],
-    "name:oci_x_preferred":[
-        "Montenegro"
+    "name:oci_x_preferred": [
+      "Montenegro"
     ],
-    "name:olo_x_preferred":[
-        "Montenegro"
+    "name:olo_x_preferred": [
+      "Montenegro"
     ],
-    "name:ori_x_preferred":[
-        "\u0b2e\u0b4b\u0b23\u0b4d\u0b1f\u0b47\u0b28\u0b47\u0b17\u0b4d\u0b30\u0b4b"
+    "name:ori_x_preferred": [
+      "ମୋଣ୍ଟେନେଗ୍ରୋ"
     ],
-    "name:ori_x_variant":[
-        "\u0b2e\u0b23\u0b4d\u0b1f\u0b47\u0b17\u0b4d\u0b30\u0b4b"
+    "name:ori_x_variant": [
+      "ମଣ୍ଟେଗ୍ରୋ"
     ],
-    "name:orm_x_preferred":[
-        "Moonteneegroo"
+    "name:orm_x_preferred": [
+      "Moonteneegroo"
     ],
-    "name:oss_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438"
+    "name:oss_x_preferred": [
+      "Черногори"
     ],
-    "name:pag_x_preferred":[
-        "Montenegro"
+    "name:pag_x_preferred": [
+      "Montenegro"
     ],
-    "name:pam_x_preferred":[
-        "Montenegru"
+    "name:pam_x_preferred": [
+      "Montenegru"
     ],
-    "name:pan_x_preferred":[
-        "\u0a2e\u0a4b\u0a02\u0a1f\u0a47\u0a28\u0a47\u0a17\u0a30\u0a4b"
+    "name:pan_x_preferred": [
+      "ਮੋਂਟੇਨੇਗਰੋ"
     ],
-    "name:pap_x_preferred":[
-        "Montenegro"
+    "name:pap_x_preferred": [
+      "Montenegro"
     ],
-    "name:pcd_x_preferred":[
-        "No\u00e9rmont"
+    "name:pcd_x_preferred": [
+      "Noérmont"
     ],
-    "name:pih_x_preferred":[
-        "Montiniegrow"
+    "name:pih_x_preferred": [
+      "Montiniegrow"
     ],
-    "name:pms_x_preferred":[
-        "Montn\u00e8igr"
+    "name:pms_x_preferred": [
+      "Montnèigr"
     ],
-    "name:pnb_x_preferred":[
-        "\u0645\u0648\u0646\u0679\u06cc \u0646\u06cc\u06af\u0631\u0648"
+    "name:pnb_x_preferred": [
+      "مونٹی نیگرو"
     ],
-    "name:pnt_x_preferred":[
-        "\u039c\u03b1\u03c5\u03c1\u03bf\u03b2\u03bf\u03cd\u03bd\u03b9\u03bf\u03bd"
+    "name:pnt_x_preferred": [
+      "Μαυροβούνιον"
     ],
-    "name:pol_x_preferred":[
-        "Czarnog\u00f3ra"
+    "name:pol_x_preferred": [
+      "Czarnogóra"
     ],
-    "name:por_x_preferred":[
-        "Montenegro"
+    "name:por_x_preferred": [
+      "Montenegro"
     ],
-    "name:pus_x_preferred":[
-        "\u0645\u0627\u0646\u062a\u06d0\u0646\u06d0\u06af\u0631\u0648"
+    "name:pus_x_preferred": [
+      "مانتېنېگرو"
     ],
-    "name:pus_x_variant":[
-        "\u0645\u0627\u0646\u062a\u06d0\u0646\u06d0\u06ab\u0631\u0648"
+    "name:pus_x_variant": [
+      "مانتېنېګرو"
     ],
-    "name:que_x_preferred":[
-        "Yanaurqu"
+    "name:que_x_preferred": [
+      "Yanaurqu"
     ],
-    "name:rmy_x_preferred":[
-        "Montenegro"
+    "name:rmy_x_preferred": [
+      "Montenegro"
     ],
-    "name:roh_x_preferred":[
-        "Montenegro"
+    "name:roh_x_preferred": [
+      "Montenegro"
     ],
-    "name:ron_x_preferred":[
-        "Muntenegru"
+    "name:ron_x_preferred": [
+      "Muntenegru"
     ],
-    "name:rue_x_preferred":[
-        "\u0427\u043e\u0440\u043d\u0430 \u0413\u043e\u0440\u0430"
+    "name:rue_x_preferred": [
+      "Чорна Гора"
     ],
-    "name:rup_x_preferred":[
-        "Montenegro"
+    "name:rup_x_preferred": [
+      "Montenegro"
     ],
-    "name:rus_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:rus_x_preferred": [
+      "Черногория"
     ],
-    "name:sah_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:sah_x_preferred": [
+      "Черногория"
     ],
-    "name:sah_x_variant":[
-        "\u041c\u043e\u043d\u0442\u0435\u043d\u0435\u0433\u0440\u043e"
+    "name:sah_x_variant": [
+      "Монтенегро"
     ],
-    "name:scn_x_preferred":[
-        "Montenegru"
+    "name:scn_x_preferred": [
+      "Montenegru"
     ],
-    "name:sco_x_preferred":[
-        "Montenegro"
+    "name:sco_x_preferred": [
+      "Montenegro"
     ],
-    "name:sgs_x_preferred":[
-        "Joudkaln\u0117j\u0117"
+    "name:sgs_x_preferred": [
+      "Joudkalnėjė"
     ],
-    "name:shn_x_preferred":[
-        "\u1019\u102d\u1030\u1004\u103a\u1038\u1019\u103d\u107c\u103a\u1087\u1010\u1031\u1087\u107c\u1031\u1038\u1075\u101b\u1030\u101d\u103a\u1087"
+    "name:shn_x_preferred": [
+      "မိူင်းမွၼ်ႇတေႇၼေးၵရူဝ်ႇ"
     ],
-    "name:sin_x_preferred":[
-        "\u0db8\u0ddc\u0db1\u0dca\u0da7\u0dd2\u0db1\u0dd2\u0d9c\u0dca\u200d\u0dbb\u0ddd"
+    "name:sin_x_preferred": [
+      "මොන්ටිනිග්‍රෝ"
     ],
-    "name:sin_x_variant":[
-        "\u0db8\u0ddc\u0db1\u0dca\u0da9\u0dd2\u0db1\u0dd3\u0d9c\u0dca\u200d\u0dbb\u0ddd"
+    "name:sin_x_variant": [
+      "මොන්ඩිනීග්‍රෝ"
     ],
-    "name:slk_x_preferred":[
-        "\u010cierna Hora"
+    "name:slk_x_preferred": [
+      "Čierna Hora"
     ],
-    "name:slv_x_preferred":[
-        "\u010crna gora"
+    "name:slv_x_preferred": [
+      "Črna gora"
     ],
-    "name:sme_x_preferred":[
-        "Montenegro"
+    "name:sme_x_preferred": [
+      "Montenegro"
     ],
-    "name:smn_x_preferred":[
-        "Montenegro"
+    "name:smn_x_preferred": [
+      "Montenegro"
     ],
-    "name:smo_x_preferred":[
-        "Montenegro"
+    "name:smo_x_preferred": [
+      "Montenegro"
     ],
-    "name:sms_x_preferred":[
-        "Montenegro"
+    "name:sms_x_preferred": [
+      "Montenegro"
     ],
-    "name:sna_x_preferred":[
-        "Montenegro"
+    "name:sna_x_preferred": [
+      "Montenegro"
     ],
-    "name:som_x_preferred":[
-        "Montenegro"
+    "name:som_x_preferred": [
+      "Montenegro"
     ],
-    "name:spa_x_preferred":[
-        "Montenegro"
+    "name:spa_x_preferred": [
+      "Montenegro"
     ],
-    "name:sqi_x_preferred":[
-        "Mali i Zi"
+    "name:sqi_x_preferred": [
+      "Mali i Zi"
     ],
-    "name:srd_x_preferred":[
-        "Montenegro"
+    "name:srd_x_preferred": [
+      "Montenegro"
     ],
-    "name:srn_x_preferred":[
-        "Montenegrokondre"
+    "name:srn_x_preferred": [
+      "Montenegrokondre"
     ],
-    "name:srp_x_preferred":[
-        "\u0426\u0440\u043d\u0430 \u0413\u043e\u0440\u0430"
+    "name:srp_x_preferred": [
+      "Црна Гора"
     ],
-    "name:srp_x_variant":[
-        "Republika Crna Gora",
-        "Crna Gora"
+    "name:srp_x_variant": [
+      "Republika Crna Gora",
+      "Crna Gora"
     ],
-    "name:ssw_x_preferred":[
-        "IMonthenekho"
+    "name:ssw_x_preferred": [
+      "IMonthenekho"
     ],
-    "name:stq_x_preferred":[
-        "Montenegro"
+    "name:stq_x_preferred": [
+      "Montenegro"
     ],
-    "name:sun_x_preferred":[
-        "Mont\u00e9n\u00e9gro"
+    "name:sun_x_preferred": [
+      "Monténégro"
     ],
-    "name:swa_x_preferred":[
-        "Montenegro"
+    "name:swa_x_preferred": [
+      "Montenegro"
     ],
-    "name:swe_x_preferred":[
-        "Montenegro"
+    "name:swe_x_preferred": [
+      "Montenegro"
     ],
-    "name:szl_x_preferred":[
-        "Czorno G\u016fra"
+    "name:szl_x_preferred": [
+      "Czorno Gůra"
     ],
-    "name:szy_x_preferred":[
-        "Montenegro"
+    "name:szy_x_preferred": [
+      "Montenegro"
     ],
-    "name:tam_x_preferred":[
-        "\u0bae\u0bca\u0ba3\u0bcd\u0b9f\u0bc6\u0ba9\u0bc7\u0b95\u0bc1\u0bb0\u0bcb"
+    "name:tam_x_preferred": [
+      "மொண்டெனேகுரோ"
     ],
-    "name:tam_x_variant":[
-        "\u0bae\u0bbe\u0ba9\u0bcd\u0b9f\u0bc7\u0ba9\u0bc6\u0b95\u0bcd\u0bb0\u0bcb"
+    "name:tam_x_variant": [
+      "மான்டேனெக்ரோ"
     ],
-    "name:tat_x_preferred":[
-        "\u041c\u043e\u043d\u0442\u0435\u043d\u0435\u0433\u0440\u043e"
+    "name:tat_x_preferred": [
+      "Монтенегро"
     ],
-    "name:tat_x_variant":[
-        "\u041a\u0430\u0440\u0430\u0442\u0430\u0443"
+    "name:tat_x_variant": [
+      "Каратау"
     ],
-    "name:tay_x_preferred":[
-        "Montenegro"
+    "name:tay_x_preferred": [
+      "Montenegro"
     ],
-    "name:tel_x_preferred":[
-        "\u0c2e\u0c4b\u0c02\u0c1f\u0c47\u0c28\u0c47\u0c17\u0c4d\u0c30\u0c4b"
+    "name:tel_x_preferred": [
+      "మోంటేనేగ్రో"
     ],
-    "name:tel_x_variant":[
-        "\u0c2e\u0c4a\u0c02\u0c1f\u0c46\u0c28\u0c47\u0c17\u0c4d\u0c30\u0c4b"
+    "name:tel_x_variant": [
+      "మొంటెనేగ్రో"
     ],
-    "name:tet_x_preferred":[
-        "Montenegru"
+    "name:tet_x_preferred": [
+      "Montenegru"
     ],
-    "name:tgk_x_preferred":[
-        "\u041c\u043e\u043d\u0442\u0435\u043d\u0435\u0433\u0440\u043e"
+    "name:tgk_x_preferred": [
+      "Монтенегро"
     ],
-    "name:tgl_x_preferred":[
-        "Montenegro"
+    "name:tgl_x_preferred": [
+      "Montenegro"
     ],
-    "name:tha_x_preferred":[
-        "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e21\u0e2d\u0e19\u0e40\u0e15\u0e40\u0e19\u0e42\u0e01\u0e23"
+    "name:tha_x_preferred": [
+      "ประเทศมอนเตเนโกร"
     ],
-    "name:tha_x_variant":[
-        "\u0e21\u0e2d\u0e19\u0e40\u0e15\u0e40\u0e19\u0e42\u0e01\u0e23"
+    "name:tha_x_variant": [
+      "มอนเตเนโกร"
     ],
-    "name:tok_x_preferred":[
-        "ma Sinakola"
+    "name:tok_x_preferred": [
+      "ma Sinakola"
     ],
-    "name:ton_x_preferred":[
-        "Monitenikalo"
+    "name:ton_x_preferred": [
+      "Monitenikalo"
     ],
-    "name:trv_x_preferred":[
-        "Montenegro"
+    "name:trv_x_preferred": [
+      "Montenegro"
     ],
-    "name:tso_x_preferred":[
-        "Montenegro"
+    "name:tso_x_preferred": [
+      "Montenegro"
     ],
-    "name:tuk_x_preferred":[
-        "\u00c7ernogori\u00fda"
+    "name:tuk_x_preferred": [
+      "Çernogoriýa"
     ],
-    "name:tum_x_preferred":[
-        "Montenegro"
+    "name:tum_x_preferred": [
+      "Montenegro"
     ],
-    "name:tur_x_preferred":[
-        "Karada\u011f"
+    "name:tur_x_preferred": [
+      "Karadağ"
     ],
-    "name:tyv_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:tyv_x_preferred": [
+      "Черногория"
     ],
-    "name:udm_x_preferred":[
-        "\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f"
+    "name:udm_x_preferred": [
+      "Черногория"
     ],
-    "name:uig_x_preferred":[
-        "\u0645\u0648\u0646\u062a\u0647\u200c\u0646\u06d5\u06af\u0631\u0648"
+    "name:uig_x_preferred": [
+      "مونته‌نەگرو"
     ],
-    "name:uig_x_variant":[
-        "\u0686\u06d0\u0631\u0646\u0648\u06af\u0648\u0631\u0649\u064a\u06d5"
+    "name:uig_x_variant": [
+      "چېرنوگورىيە"
     ],
-    "name:ukr_x_preferred":[
-        "\u0427\u043e\u0440\u043d\u043e\u0433\u043e\u0440\u0456\u044f"
+    "name:ukr_x_preferred": [
+      "Чорногорія"
     ],
-    "name:urd_x_preferred":[
-        "\u0645\u0648\u0646\u0679\u06cc\u0646\u06cc\u06af\u0631\u0648"
+    "name:urd_x_preferred": [
+      "مونٹینیگرو"
     ],
-    "name:urd_x_variant":[
-        "\u0645\u0648\u0646\u0679\u06d2 \u0646\u06cc\u06af\u0631\u0648"
+    "name:urd_x_variant": [
+      "مونٹے نیگرو"
     ],
-    "name:uzb_x_preferred":[
-        "Chernogoriya"
+    "name:uzb_x_preferred": [
+      "Chernogoriya"
     ],
-    "name:vec_x_preferred":[
-        "Monten\u00e9gro"
+    "name:vec_x_preferred": [
+      "Montenégro"
     ],
-    "name:vec_x_variant":[
-        "Montenegro"
+    "name:vec_x_variant": [
+      "Montenegro"
     ],
-    "name:vep_x_preferred":[
-        "Mustm\u00e4gi"
+    "name:vep_x_preferred": [
+      "Mustmägi"
     ],
-    "name:vie_x_preferred":[
-        "Montenegro"
+    "name:vie_x_preferred": [
+      "Montenegro"
     ],
-    "name:vls_x_preferred":[
-        "Montenegro"
+    "name:vls_x_preferred": [
+      "Montenegro"
     ],
-    "name:vol_x_preferred":[
-        "Montenegr\u00e4n"
+    "name:vol_x_preferred": [
+      "Montenegrän"
     ],
-    "name:vro_x_preferred":[
-        "Mont\u00f5negro"
+    "name:vro_x_preferred": [
+      "Montõnegro"
     ],
-    "name:war_x_preferred":[
-        "Montenegro"
+    "name:war_x_preferred": [
+      "Montenegro"
     ],
-    "name:wln_x_preferred":[
-        "Montenegro"
+    "name:wln_x_preferred": [
+      "Montenegro"
     ],
-    "name:wol_x_preferred":[
-        "Montenegro"
+    "name:wol_x_preferred": [
+      "Montenegro"
     ],
-    "name:wuu_x_preferred":[
-        "\u9ed1\u5c71\u5171\u548c\u56fd"
+    "name:wuu_x_preferred": [
+      "黑山共和国"
     ],
-    "name:xal_x_preferred":[
-        "\u0425\u0430\u0440 \u0423\u0443\u043b\u0438\u043d \u041e\u0440\u043d"
+    "name:xal_x_preferred": [
+      "Хар Уулин Орн"
     ],
-    "name:xmf_x_preferred":[
-        "\u10e9\u10d4\u10e0\u10dc\u10dd\u10d2\u10dd\u10e0\u10d8\u10d0"
+    "name:xmf_x_preferred": [
+      "ჩერნოგორია"
     ],
-    "name:xmf_x_variant":[
-        "\u10db\u10dd\u10dc\u10e2\u10d4\u10dc\u10d4\u10d2\u10e0\u10dd"
+    "name:xmf_x_variant": [
+      "მონტენეგრო"
     ],
-    "name:yid_x_preferred":[
-        "\u05de\u05d0\u05e0\u05d8\u05e2\u05e0\u05e2\u05d2\u05e8\u05d0"
+    "name:yid_x_preferred": [
+      "מאנטענעגרא"
     ],
-    "name:yor_x_preferred":[
-        "Montenegro"
+    "name:yor_x_preferred": [
+      "Montenegro"
     ],
-    "name:yor_x_variant":[
-        "Monten\u1eb9\u0301gr\u00f2"
+    "name:yor_x_variant": [
+      "Montenẹ́grò"
     ],
-    "name:yue_x_preferred":[
-        "\u9ed1\u5c71"
+    "name:yue_x_preferred": [
+      "黑山"
     ],
-    "name:zea_x_preferred":[
-        "Montenehro"
+    "name:zea_x_preferred": [
+      "Montenehro"
     ],
-    "name:zha_x_preferred":[
-        "Montenegro"
+    "name:zha_x_preferred": [
+      "Montenegro"
     ],
-    "name:zho_min_nan_x_preferred":[
-        "O\u0358-soa\u207f Ki\u014dng-h\u00f4-kok"
+    "name:zho_min_nan_x_preferred": [
+      "O͘-soaⁿ Kiōng-hô-kok"
     ],
-    "name:zho_x_preferred":[
-        "\u8499\u7279\u5167\u54e5\u7f85"
+    "name:zho_x_preferred": [
+      "蒙特內哥羅"
     ],
-    "name:zho_x_variant":[
-        "\u9ed1\u5c71",
-        "\u9ed1\u5c71\u5171\u548c\u56fd"
+    "name:zho_x_variant": [
+      "黑山",
+      "黑山共和国"
     ],
-    "name:zho_yue_x_preferred":[
-        "\u9ed1\u5c71"
+    "name:zho_yue_x_preferred": [
+      "黑山"
     ],
-    "name:zul_x_preferred":[
-        "IMontenegro"
+    "name:zul_x_preferred": [
+      "IMontenegro"
     ],
-    "name:zul_x_variant":[
-        "i-Montenegro"
+    "name:zul_x_variant": [
+      "i-Montenegro"
     ],
-    "ne:abbrev":"Mont.",
-    "ne:abbrev_len":5,
-    "ne:adm0_a3":"MNE",
-    "ne:adm0_a3_ar":"MNE",
-    "ne:adm0_a3_bd":"MNE",
-    "ne:adm0_a3_br":"MNE",
-    "ne:adm0_a3_cn":"MNE",
-    "ne:adm0_a3_de":"MNE",
-    "ne:adm0_a3_eg":"MNE",
-    "ne:adm0_a3_es":"MNE",
-    "ne:adm0_a3_fr":"MNE",
-    "ne:adm0_a3_gb":"MNE",
-    "ne:adm0_a3_gr":"MNE",
-    "ne:adm0_a3_id":"MNE",
-    "ne:adm0_a3_il":"MNE",
-    "ne:adm0_a3_in":"MNE",
-    "ne:adm0_a3_is":"MNE",
-    "ne:adm0_a3_it":"MNE",
-    "ne:adm0_a3_jp":"MNE",
-    "ne:adm0_a3_ko":"MNE",
-    "ne:adm0_a3_ma":"MNE",
-    "ne:adm0_a3_nl":"MNE",
-    "ne:adm0_a3_np":"MNE",
-    "ne:adm0_a3_pk":"MNE",
-    "ne:adm0_a3_pl":"MNE",
-    "ne:adm0_a3_ps":"MNE",
-    "ne:adm0_a3_pt":"MNE",
-    "ne:adm0_a3_ru":"MNE",
-    "ne:adm0_a3_sa":"MNE",
-    "ne:adm0_a3_se":"MNE",
-    "ne:adm0_a3_tr":"MNE",
-    "ne:adm0_a3_tw":"MNE",
-    "ne:adm0_a3_ua":"MNE",
-    "ne:adm0_a3_un":-99,
-    "ne:adm0_a3_us":"MNE",
-    "ne:adm0_a3_vn":"MNE",
-    "ne:adm0_a3_wb":-99,
-    "ne:adm0_dif":0,
-    "ne:admin":"Montenegro",
-    "ne:brk_a3":"MNE",
-    "ne:brk_diff":0,
-    "ne:brk_group":null,
-    "ne:brk_name":"Montenegro",
-    "ne:continent":"Europe",
-    "ne:economy":"6. Developing region",
-    "ne:featurecla":"Admin-0 country",
-    "ne:fips_10":"MJ",
-    "ne:fips_10_":"MJ",
-    "ne:formal_en":"Montenegro",
-    "ne:formal_fr":null,
-    "ne:gdp_md":5542,
-    "ne:gdp_md_est":6816,
-    "ne:gdp_year":2019,
-    "ne:geou_dif":0,
-    "ne:geounit":"Montenegro",
-    "ne:gu_a3":"MNE",
-    "ne:homepart":1,
-    "ne:income_grp":"3. Upper middle income",
-    "ne:iso_a2":"ME",
-    "ne:iso_a2_eh":"ME",
-    "ne:iso_a3":"MNE",
-    "ne:iso_a3_eh":"MNE",
-    "ne:iso_n3":"499",
-    "ne:iso_n3_eh":"499",
-    "ne:labelrank":6,
-    "ne:lastcensus":2011,
-    "ne:level":2,
-    "ne:long_len":10,
-    "ne:mapcolor13":5,
-    "ne:mapcolor7":4,
-    "ne:mapcolor8":1,
-    "ne:mapcolor9":4,
-    "ne:max_label":10,
-    "ne:min_label":5,
-    "ne:min_zoom":0,
-    "ne:name_alt":null,
-    "ne:name_ar":"\u0627\u0644\u062c\u0628\u0644 \u0627\u0644\u0623\u0633\u0648\u062f",
-    "ne:name_bn":"\u09ae\u09a8\u09cd\u099f\u09bf\u09a8\u09bf\u0997\u09cd\u09b0\u09cb",
-    "ne:name_ciawf":"Montenegro",
-    "ne:name_de":"Montenegro",
-    "ne:name_el":"\u039c\u03b1\u03c5\u03c1\u03bf\u03b2\u03bf\u03cd\u03bd\u03b9\u03bf",
-    "ne:name_en":"Montenegro",
-    "ne:name_es":"Montenegro",
-    "ne:name_fr":"Mont\u00e9n\u00e9gro",
-    "ne:name_he":"\u05de\u05d5\u05e0\u05d8\u05e0\u05d2\u05e8\u05d5",
-    "ne:name_hi":"\u092e\u0949\u0928\u094d\u091f\u0947\u0928\u0940\u0917\u094d\u0930\u094b",
-    "ne:name_hu":"Montenegr\u00f3",
-    "ne:name_id":"Montenegro",
-    "ne:name_it":"Montenegro",
-    "ne:name_ja":"\u30e2\u30f3\u30c6\u30cd\u30b0\u30ed",
-    "ne:name_ko":"\ubaac\ud14c\ub124\uadf8\ub85c",
-    "ne:name_len":10,
-    "ne:name_long":"Montenegro",
-    "ne:name_nl":"Montenegro",
-    "ne:name_pl":"Czarnog\u00f3ra",
-    "ne:name_pt":"Montenegro",
-    "ne:name_ru":"\u0427\u0435\u0440\u043d\u043e\u0433\u043e\u0440\u0438\u044f",
-    "ne:name_sort":"Montenegro",
-    "ne:name_sv":"Montenegro",
-    "ne:name_tr":"Karada\u011f",
-    "ne:name_uk":"\u0427\u043e\u0440\u043d\u043e\u0433\u043e\u0440\u0456\u044f",
-    "ne:name_ur":"\u0645\u0648\u0646\u0679\u06cc\u0646\u06cc\u06af\u0631\u0648",
-    "ne:name_vi":"Montenegro",
-    "ne:name_zh":"\u8499\u7279\u5167\u54e5\u7f85",
-    "ne:note_adm0":null,
-    "ne:note_brk":null,
-    "ne:pop_est":622137,
-    "ne:pop_rank":11,
-    "ne:pop_year":2019,
-    "ne:postal":"ME",
-    "ne:region_un":"Europe",
-    "ne:region_wb":"Europe & Central Asia",
-    "ne:scalerank":0,
-    "ne:sov_a3":"MNE",
-    "ne:sovereignt":"Montenegro",
-    "ne:su_a3":"MNE",
-    "ne:su_dif":0,
-    "ne:subregion":"Southern Europe",
-    "ne:subunit":"Montenegro",
-    "ne:tiny":-99,
-    "ne:type":"Sovereign country",
-    "ne:un_a3":"499",
-    "ne:wb_a2":"ME",
-    "ne:wb_a3":"MNE",
-    "ne:wikidataid":"Q236",
-    "ne:wikipedia":"-99",
-    "ne:woe_id":20069817,
-    "ne:woe_id_eh":20069817,
-    "ne:woe_note":"Exact WOE match as country",
-    "qs:a0":"Montenegro",
-    "qs:a0_alt":"Montenegro",
-    "qs:adm0":"Montenegro",
-    "qs:adm0_a3":"MNE",
-    "qs:level":"adm0",
-    "qs:scale":200000,
-    "qs:source":"US State Department, with Natural Earth mods",
-    "src:geom":"quattroshapes",
-    "src:geom_alt":[
-        "naturalearth",
-        "whosonfirst"
+    "ne:abbrev": "Mont.",
+    "ne:abbrev_len": 5,
+    "ne:adm0_a3": "MNE",
+    "ne:adm0_a3_ar": "MNE",
+    "ne:adm0_a3_bd": "MNE",
+    "ne:adm0_a3_br": "MNE",
+    "ne:adm0_a3_cn": "MNE",
+    "ne:adm0_a3_de": "MNE",
+    "ne:adm0_a3_eg": "MNE",
+    "ne:adm0_a3_es": "MNE",
+    "ne:adm0_a3_fr": "MNE",
+    "ne:adm0_a3_gb": "MNE",
+    "ne:adm0_a3_gr": "MNE",
+    "ne:adm0_a3_id": "MNE",
+    "ne:adm0_a3_il": "MNE",
+    "ne:adm0_a3_in": "MNE",
+    "ne:adm0_a3_is": "MNE",
+    "ne:adm0_a3_it": "MNE",
+    "ne:adm0_a3_jp": "MNE",
+    "ne:adm0_a3_ko": "MNE",
+    "ne:adm0_a3_ma": "MNE",
+    "ne:adm0_a3_nl": "MNE",
+    "ne:adm0_a3_np": "MNE",
+    "ne:adm0_a3_pk": "MNE",
+    "ne:adm0_a3_pl": "MNE",
+    "ne:adm0_a3_ps": "MNE",
+    "ne:adm0_a3_pt": "MNE",
+    "ne:adm0_a3_ru": "MNE",
+    "ne:adm0_a3_sa": "MNE",
+    "ne:adm0_a3_se": "MNE",
+    "ne:adm0_a3_tr": "MNE",
+    "ne:adm0_a3_tw": "MNE",
+    "ne:adm0_a3_ua": "MNE",
+    "ne:adm0_a3_un": -99,
+    "ne:adm0_a3_us": "MNE",
+    "ne:adm0_a3_vn": "MNE",
+    "ne:adm0_a3_wb": -99,
+    "ne:adm0_dif": 0,
+    "ne:admin": "Montenegro",
+    "ne:brk_a3": "MNE",
+    "ne:brk_diff": 0,
+    "ne:brk_group": null,
+    "ne:brk_name": "Montenegro",
+    "ne:continent": "Europe",
+    "ne:economy": "6. Developing region",
+    "ne:featurecla": "Admin-0 country",
+    "ne:fips_10": "MJ",
+    "ne:fips_10_": "MJ",
+    "ne:formal_en": "Montenegro",
+    "ne:formal_fr": null,
+    "ne:gdp_md": 5542,
+    "ne:gdp_md_est": 6816,
+    "ne:gdp_year": 2019,
+    "ne:geou_dif": 0,
+    "ne:geounit": "Montenegro",
+    "ne:gu_a3": "MNE",
+    "ne:homepart": 1,
+    "ne:income_grp": "3. Upper middle income",
+    "ne:iso_a2": "ME",
+    "ne:iso_a2_eh": "ME",
+    "ne:iso_a3": "MNE",
+    "ne:iso_a3_eh": "MNE",
+    "ne:iso_n3": "499",
+    "ne:iso_n3_eh": "499",
+    "ne:labelrank": 6,
+    "ne:lastcensus": 2011,
+    "ne:level": 2,
+    "ne:long_len": 10,
+    "ne:mapcolor13": 5,
+    "ne:mapcolor7": 4,
+    "ne:mapcolor8": 1,
+    "ne:mapcolor9": 4,
+    "ne:max_label": 10,
+    "ne:min_label": 5,
+    "ne:min_zoom": 0,
+    "ne:name_alt": null,
+    "ne:name_ar": "الجبل الأسود",
+    "ne:name_bn": "মন্টিনিগ্রো",
+    "ne:name_ciawf": "Montenegro",
+    "ne:name_de": "Montenegro",
+    "ne:name_el": "Μαυροβούνιο",
+    "ne:name_en": "Montenegro",
+    "ne:name_es": "Montenegro",
+    "ne:name_fr": "Monténégro",
+    "ne:name_he": "מונטנגרו",
+    "ne:name_hi": "मॉन्टेनीग्रो",
+    "ne:name_hu": "Montenegró",
+    "ne:name_id": "Montenegro",
+    "ne:name_it": "Montenegro",
+    "ne:name_ja": "モンテネグロ",
+    "ne:name_ko": "몬테네그로",
+    "ne:name_len": 10,
+    "ne:name_long": "Montenegro",
+    "ne:name_nl": "Montenegro",
+    "ne:name_pl": "Czarnogóra",
+    "ne:name_pt": "Montenegro",
+    "ne:name_ru": "Черногория",
+    "ne:name_sort": "Montenegro",
+    "ne:name_sv": "Montenegro",
+    "ne:name_tr": "Karadağ",
+    "ne:name_uk": "Чорногорія",
+    "ne:name_ur": "مونٹینیگرو",
+    "ne:name_vi": "Montenegro",
+    "ne:name_zh": "蒙特內哥羅",
+    "ne:note_adm0": null,
+    "ne:note_brk": null,
+    "ne:pop_est": 622137,
+    "ne:pop_rank": 11,
+    "ne:pop_year": 2019,
+    "ne:postal": "ME",
+    "ne:region_un": "Europe",
+    "ne:region_wb": "Europe \u0026 Central Asia",
+    "ne:scalerank": 0,
+    "ne:sov_a3": "MNE",
+    "ne:sovereignt": "Montenegro",
+    "ne:su_a3": "MNE",
+    "ne:su_dif": 0,
+    "ne:subregion": "Southern Europe",
+    "ne:subunit": "Montenegro",
+    "ne:tiny": -99,
+    "ne:type": "Sovereign country",
+    "ne:un_a3": "499",
+    "ne:wb_a2": "ME",
+    "ne:wb_a3": "MNE",
+    "ne:wikidataid": "Q236",
+    "ne:wikipedia": "-99",
+    "ne:woe_id": 20069817,
+    "ne:woe_id_eh": 20069817,
+    "ne:woe_note": "Exact WOE match as country",
+    "qs:a0": "Montenegro",
+    "qs:a0_alt": "Montenegro",
+    "qs:adm0": "Montenegro",
+    "qs:adm0_a3": "MNE",
+    "qs:level": "adm0",
+    "qs:scale": 200000,
+    "qs:source": "US State Department, with Natural Earth mods",
+    "src:geom": "quattroshapes",
+    "src:geom_alt": [
+      "naturalearth",
+      "whosonfirst"
     ],
-    "src:lbl_centroid":"mapshaper",
-    "src:population":"eurostat",
-    "src:population_date":"2022",
-    "statoids:dial":"382",
-    "statoids:ds":"MNE",
-    "statoids:fifa":"MNE",
-    "statoids:gaul":"2647",
-    "statoids:gec":"MJ",
-    "statoids:independent":"Yes",
-    "statoids:ioc":"MGO",
-    "statoids:iso_a2":"ME",
-    "statoids:iso_a3":"MNE",
-    "statoids:iso_num":"499",
-    "statoids:itu":"MNE",
-    "statoids:marc":"mo",
-    "statoids:name":"Montenegro",
-    "statoids:wmo":"",
-    "wd:latitude":42.766667,
-    "wd:longitude":19.216667,
-    "wd:wordcount":8658,
-    "wof:belongsto":[
-        102191581
+    "src:lbl_centroid": "mapshaper",
+    "src:population": "eurostat",
+    "src:population_date": "2022",
+    "statoids:dial": "382",
+    "statoids:ds": "MNE",
+    "statoids:fifa": "MNE",
+    "statoids:gaul": "2647",
+    "statoids:gec": "MJ",
+    "statoids:independent": "Yes",
+    "statoids:ioc": "MGO",
+    "statoids:iso_a2": "ME",
+    "statoids:iso_a3": "MNE",
+    "statoids:iso_num": "499",
+    "statoids:itu": "MNE",
+    "statoids:marc": "mo",
+    "statoids:name": "Montenegro",
+    "statoids:wmo": "",
+    "wd:latitude": 42.766667,
+    "wd:longitude": 19.216667,
+    "wd:wordcount": 8658,
+    "wof:belongsto": [
+      102191581
     ],
-    "wof:breaches":[],
-    "wof:capital":[
-        1125934969,
-        421179031
+    "wof:breaches": [],
+    "wof:capital": [
+      1125934969,
+      421179031
     ],
-    "wof:concordances":{
-        "dbp:id":"Montenegro",
-        "digitalenvoy:country_code":499,
-        "eurostat:nuts_2021_id":"ME000",
-        "fb:id":"en.montenegro",
-        "fifa:id":"MNE",
-        "fips:code":"MJ",
-        "gaul:id":"2647",
-        "gn:id":3194884,
-        "gp:id":20069817,
-        "hasc:id":"ME",
-        "icao:code":"YU",
-        "ioc:id":"MGO",
-        "iso:code":"ME",
-        "itu:id":"MNE",
-        "m49:code":"499",
-        "marc:id":"mo",
-        "mzb:id":"montenegro",
-        "ne:adm0_a3":"MNE",
-        "ne:id":1159321069,
-        "nyt:id":"11974025787996384181",
-        "qs_pg:id":1251621,
-        "uncrt:id":"MNE",
-        "wd:id":"Q236",
-        "wk:page":"Montenegro"
+    "wof:concordances": {
+      "dbp:id": "Montenegro",
+      "digitalenvoy:country_code": 499,
+      "eurostat:nuts_2021_id": "ME000",
+      "fb:id": "en.montenegro",
+      "fifa:id": "MNE",
+      "fips:code": "MJ",
+      "gaul:id": "2647",
+      "gn:id": 3194884,
+      "gp:id": 20069817,
+      "hasc:id": "ME",
+      "icao:code": "YU",
+      "ioc:id": "MGO",
+      "iso:code": "ME",
+      "itu:id": "MNE",
+      "m49:code": "499",
+      "marc:id": "mo",
+      "mzb:id": "montenegro",
+      "ne:adm0_a3": "MNE",
+      "ne:id": 1159321069,
+      "nyt:id": "11974025787996384181",
+      "qs_pg:id": 1251621,
+      "uncrt:id": "MNE",
+      "wd:id": "Q236",
+      "wk:page": "Montenegro"
     },
-    "wof:concordances_official":"iso:code",
-    "wof:country":"ME",
-    "wof:country_alpha3":"MNE",
-    "wof:geom_alt":[
-        "naturalearth",
-        "naturalearth-display-terrestrial-zoom6",
-        "whosonfirst-interior"
+    "wof:concordances_official": "iso:code",
+    "wof:country": "ME",
+    "wof:country_alpha3": "MNE",
+    "wof:created": 1712250589,
+    "wof:geom_alt": [
+      "naturalearth",
+      "naturalearth-display-terrestrial-zoom6",
+      "whosonfirst-interior"
     ],
-    "wof:geomhash":"2f9593f1e7194ac9ebfe47131de56606",
-    "wof:hierarchy":[
-        {
-            "continent_id":102191581,
-            "country_id":85632667
-        }
+    "wof:geomhash": "3d9037662ed653a36db31572af3bbecc",
+    "wof:hierarchy": [
+      {
+        "continent_id": 102191581,
+        "country_id": 85632667
+      }
     ],
-    "wof:id":85632667,
-    "wof:lang_x_official":[
-        "srp"
+    "wof:id": 85632667,
+    "wof:lang_x_official": [
+      "srp"
     ],
-    "wof:lang_x_spoken":[
-        "srp"
+    "wof:lang_x_spoken": [
+      "srp"
     ],
-    "wof:lastmodified":1695881377,
-    "wof:name":"Montenegro",
-    "wof:parent_id":102191581,
-    "wof:placetype":"country",
-    "wof:population":617683,
-    "wof:population_rank":11,
-    "wof:repo":"whosonfirst-data-admin-me",
-    "wof:shortcode":"ME",
-    "wof:superseded_by":[],
-    "wof:supersedes":[
-        1108955783
+    "wof:lastmodified": 1712250589,
+    "wof:name": "Montenegro",
+    "wof:parent_id": 102191581,
+    "wof:placetype": "country",
+    "wof:population": 617683,
+    "wof:population_rank": 11,
+    "wof:repo": "whosonfirst-data-admin-me",
+    "wof:shortcode": "ME",
+    "wof:superseded_by": [],
+    "wof:supersedes": [
+      1108955783
     ],
-    "wof:tags":[]
-},
+    "wof:tags": []
+  },
   "bbox": [
     18.43398,
     41.846345,
     20.352911,
     43.558743
-],
-  "geometry": {"coordinates":[[[[18.522544,42.42137],[18.516748,42.426381],[18.512617,42.427998],[18.508022,42.430298],[18.503369,42.432816],[18.499521,42.435768],[18.496993,42.438069],[18.492168,42.442887],[18.490215,42.445622],[18.488319,42.447575],[18.48562,42.449659],[18.483896,42.451439],[18.48292,42.452307],[18.480565,42.455563],[18.478095,42.458384],[18.47551,42.460902],[18.472121,42.463723],[18.469077,42.466024],[18.465975,42.468238],[18.463447,42.469497],[18.460633,42.470408],[18.457301,42.471233],[18.454544,42.471667],[18.452878,42.472232],[18.45127,42.473056],[18.448742,42.47527],[18.445698,42.477788],[18.443745,42.479351],[18.441907,42.480392],[18.438862,42.481695],[18.435646,42.482823],[18.43398,42.483605],[18.43668,42.489031],[18.438805,42.493242],[18.440643,42.497105],[18.440356,42.498624],[18.440758,42.500057],[18.441348,42.501699],[18.441923,42.50296],[18.442959,42.504394],[18.444052,42.505785],[18.445029,42.506959],[18.446237,42.508263],[18.44687,42.509219],[18.445432,42.510566],[18.442153,42.514565],[18.440083,42.516826],[18.43853,42.51913],[18.437667,42.520477],[18.438012,42.524433],[18.437782,42.52591],[18.438415,42.532083],[18.438472,42.534169],[18.43853,42.537647],[18.439047,42.540255],[18.439565,42.542167],[18.440198,42.543515],[18.440428,42.544862],[18.440428,42.548166],[18.440198,42.549557],[18.438932,42.552774],[18.437955,42.555555],[18.437756,42.55653],[18.441639,42.557076],[18.44471,42.557485],[18.447238,42.557758],[18.449857,42.557963],[18.452295,42.558714],[18.455004,42.559533],[18.456901,42.56042],[18.458707,42.560966],[18.460423,42.561716],[18.463854,42.56274],[18.46548,42.563081],[18.468369,42.564173],[18.470808,42.56547],[18.473155,42.567039],[18.475413,42.568131],[18.476587,42.569018],[18.479206,42.570179],[18.48056,42.570861],[18.482096,42.572294],[18.483721,42.574068],[18.485166,42.575775],[18.486972,42.577754],[18.488417,42.579528],[18.489771,42.580893],[18.491126,42.582326],[18.493113,42.584373],[18.494648,42.585465],[18.496815,42.586625],[18.499705,42.587649],[18.502143,42.588331],[18.504401,42.588468],[18.506026,42.588263],[18.508826,42.587649],[18.510541,42.586898],[18.513431,42.586284],[18.516592,42.585806],[18.518308,42.585704],[18.521017,42.585329],[18.523726,42.584646],[18.526345,42.583827],[18.528422,42.58294],[18.530499,42.581507],[18.532395,42.579528],[18.534291,42.577958],[18.535827,42.576935],[18.537362,42.575502],[18.538716,42.57441],[18.541787,42.574887],[18.544315,42.576116],[18.546573,42.577344],[18.550275,42.578846],[18.552713,42.580006],[18.553797,42.580756],[18.553887,42.582053],[18.552713,42.585806],[18.552352,42.588604],[18.551901,42.590993],[18.551359,42.593108],[18.550546,42.594132],[18.549192,42.595088],[18.547566,42.596316],[18.544044,42.597886],[18.542238,42.598977],[18.540884,42.600001],[18.539619,42.60082],[18.538626,42.601571],[18.537091,42.60198],[18.534833,42.602594],[18.53384,42.602731],[18.534201,42.604232],[18.534472,42.605256],[18.53384,42.607576],[18.533208,42.608736],[18.532576,42.60976],[18.532034,42.610784],[18.53104,42.611125],[18.530499,42.611944],[18.529686,42.613445],[18.529325,42.614128],[18.52788,42.614946],[18.525983,42.616448],[18.524719,42.617403],[18.524087,42.618563],[18.523997,42.619246],[18.525442,42.621088],[18.527248,42.623613],[18.527789,42.62491],[18.529054,42.626548],[18.529957,42.628117],[18.530408,42.629278],[18.531943,42.630574],[18.533298,42.631803],[18.535646,42.633782],[18.537542,42.635215],[18.53971,42.636511],[18.540432,42.636853],[18.543773,42.637535],[18.54567,42.638081],[18.547024,42.638422],[18.550998,42.639992],[18.553797,42.640947],[18.557319,42.64163],[18.56075,42.642585],[18.564995,42.643199],[18.567614,42.642995],[18.569058,42.643268],[18.571316,42.642926],[18.573574,42.642449],[18.575831,42.64238],[18.576825,42.642926],[18.576734,42.64395],[18.575831,42.646612],[18.574657,42.649205],[18.573664,42.651184],[18.572851,42.65289],[18.572039,42.654869],[18.571587,42.655347],[18.570232,42.655756],[18.566711,42.656916],[18.56662,42.658349],[18.566801,42.660465],[18.56644,42.661762],[18.565898,42.662171],[18.562195,42.663399],[18.559938,42.66415],[18.558673,42.664764],[18.556687,42.666334],[18.554068,42.66845],[18.551991,42.670156],[18.551178,42.670702],[18.550727,42.671384],[18.551088,42.673636],[18.551901,42.675479],[18.551991,42.677185],[18.551991,42.67855],[18.55172,42.679846],[18.550546,42.681894],[18.550004,42.683395],[18.549553,42.684623],[18.549011,42.685442],[18.548559,42.686466],[18.548018,42.687558],[18.548018,42.689127],[18.547927,42.690424],[18.547747,42.691175],[18.548559,42.691516],[18.549553,42.691243],[18.551359,42.690629],[18.553075,42.690629],[18.554158,42.690833],[18.555061,42.692403],[18.555513,42.693631],[18.555964,42.694519],[18.557138,42.697317],[18.558312,42.698954],[18.56048,42.700592],[18.562286,42.701957],[18.563369,42.702844],[18.56346,42.704619],[18.563279,42.705574],[18.563279,42.707075],[18.563279,42.708099],[18.56364,42.708986],[18.564092,42.710146],[18.565175,42.71158],[18.566349,42.712467],[18.567072,42.713968],[18.567252,42.715606],[18.567252,42.716698],[18.567523,42.718609],[18.567162,42.720246],[18.566981,42.721475],[18.563098,42.722976],[18.559215,42.724273],[18.557409,42.724887],[18.556055,42.724478],[18.555152,42.724136],[18.553887,42.723113],[18.553165,42.722362],[18.552804,42.721748],[18.55181,42.721475],[18.548469,42.721202],[18.544405,42.721407],[18.541425,42.721748],[18.53971,42.722226],[18.536459,42.723181],[18.535285,42.72359],[18.533569,42.723727],[18.532305,42.723795],[18.530047,42.723863],[18.528241,42.724682],[18.524448,42.726661],[18.523184,42.727685],[18.522642,42.727958],[18.522191,42.728845],[18.520565,42.729801],[18.519301,42.730961],[18.517314,42.733076],[18.51596,42.734919],[18.513702,42.734987],[18.510812,42.73526],[18.509638,42.73526],[18.508284,42.735328],[18.506839,42.73526],[18.503769,42.734782],[18.499344,42.73758],[18.499976,42.738741],[18.500879,42.740993],[18.501511,42.742289],[18.50133,42.743518],[18.500156,42.744064],[18.499163,42.744951],[18.497538,42.745428],[18.496002,42.74652],[18.494558,42.747612],[18.493925,42.748909],[18.492751,42.749591],[18.491668,42.750137],[18.488868,42.750342],[18.486791,42.750751],[18.485076,42.751502],[18.48327,42.751912],[18.481463,42.752116],[18.480289,42.752662],[18.478393,42.753345],[18.476406,42.753686],[18.47442,42.75471],[18.473517,42.755938],[18.472885,42.756825],[18.472885,42.757712],[18.472885,42.759282],[18.472433,42.761329],[18.47153,42.762694],[18.47153,42.763718],[18.473426,42.765083],[18.47442,42.765902],[18.474329,42.766652],[18.47451,42.767266],[18.475413,42.768563],[18.475865,42.76986],[18.475594,42.770542],[18.476587,42.771361],[18.477039,42.77177],[18.476226,42.772112],[18.475323,42.772248],[18.47451,42.772385],[18.474149,42.773272],[18.474871,42.77375],[18.476226,42.77375],[18.476948,42.773408],[18.476406,42.774295],[18.476677,42.774841],[18.475594,42.775114],[18.47451,42.775319],[18.473426,42.775729],[18.472433,42.776479],[18.471349,42.777571],[18.470627,42.778663],[18.470537,42.780437],[18.470175,42.782075],[18.469724,42.783099],[18.469995,42.784464],[18.470356,42.785897],[18.470266,42.786784],[18.469724,42.78774],[18.468098,42.788012],[18.466654,42.788558],[18.464757,42.790469],[18.464306,42.791698],[18.465209,42.792926],[18.466563,42.794223],[18.467105,42.79511],[18.467557,42.796543],[18.468008,42.797567],[18.46864,42.798659],[18.469092,42.799614],[18.469092,42.800979],[18.469724,42.801456],[18.470266,42.801729],[18.468731,42.802958],[18.467557,42.804323],[18.466654,42.805961],[18.467376,42.806848],[18.466744,42.807871],[18.466383,42.809168],[18.466202,42.81026],[18.466021,42.811557],[18.466112,42.81258],[18.46566,42.813126],[18.464306,42.813877],[18.463764,42.815242],[18.463132,42.81688],[18.462319,42.818654],[18.461687,42.819405],[18.461506,42.820224],[18.460964,42.820906],[18.459971,42.82152],[18.462409,42.822885],[18.465751,42.824182],[18.469182,42.825615],[18.472885,42.826911],[18.475684,42.828003],[18.475413,42.828686],[18.473878,42.829641],[18.472252,42.831006],[18.470717,42.832303],[18.469363,42.833395],[18.468098,42.835032],[18.467195,42.836602],[18.466202,42.838854],[18.466202,42.840697],[18.466563,42.843836],[18.466834,42.846497],[18.467286,42.848545],[18.467557,42.849978],[18.46855,42.851479],[18.470537,42.85339],[18.472433,42.855028],[18.473517,42.856051],[18.474962,42.857758],[18.477129,42.859532],[18.478845,42.860965],[18.479567,42.861374],[18.481373,42.860829],[18.48345,42.859941],[18.484985,42.859259],[18.48643,42.858781],[18.487875,42.858781],[18.48932,42.859395],[18.491397,42.860419],[18.492571,42.861716],[18.493925,42.863081],[18.494467,42.863899],[18.49528,42.864855],[18.49537,42.866902],[18.49519,42.868881],[18.494828,42.870587],[18.494196,42.871816],[18.493293,42.873931],[18.492119,42.875774],[18.491307,42.877071],[18.489771,42.878708],[18.494648,42.880414],[18.497538,42.881438],[18.501782,42.882735],[18.506116,42.884168],[18.509819,42.885465],[18.509097,42.88642],[18.507742,42.887717],[18.506207,42.889491],[18.504762,42.892152],[18.503949,42.895087],[18.503407,42.897202],[18.502504,42.899659],[18.501059,42.902798],[18.499795,42.905528],[18.497357,42.909486],[18.49537,42.911807],[18.492842,42.915628],[18.490494,42.91904],[18.488507,42.921975],[18.487243,42.92334],[18.485798,42.925319],[18.485347,42.926888],[18.484985,42.928936],[18.484805,42.931324],[18.485256,42.933713],[18.484985,42.935897],[18.485256,42.939036],[18.485347,42.942584],[18.485708,42.943881],[18.485979,42.94743],[18.486159,42.950091],[18.48643,42.951866],[18.48643,42.954868],[18.487062,42.95869],[18.487514,42.962443],[18.487424,42.963877],[18.488868,42.966197],[18.489952,42.967289],[18.491758,42.969882],[18.49239,42.972271],[18.493384,42.974318],[18.494377,42.977389],[18.49528,42.980187],[18.496093,42.982371],[18.496544,42.983804],[18.496725,42.985305],[18.497176,42.987216],[18.498441,42.989468],[18.499434,42.992129],[18.500066,42.993836],[18.500427,42.994723],[18.502775,42.995951],[18.504581,42.997043],[18.508013,42.999227],[18.509458,42.999909],[18.51027,43.003185],[18.512618,43.007894],[18.515057,43.012603],[18.518037,43.019017],[18.524268,43.022703],[18.531131,43.02632],[18.536188,43.029118],[18.540522,43.031643],[18.547476,43.03137],[18.554339,43.031097],[18.562195,43.030824],[18.574206,43.030482],[18.579263,43.030278],[18.583417,43.030141],[18.588925,43.029936],[18.593892,43.029732],[18.599942,43.029595],[18.604367,43.0298],[18.609786,43.029527],[18.614391,43.029459],[18.620261,43.029322],[18.623241,43.029186],[18.632362,43.031984],[18.637599,43.033553],[18.644643,43.035669],[18.6525,43.038057],[18.663155,43.036829],[18.661891,43.042562],[18.660988,43.04652],[18.660266,43.051228],[18.659724,43.056074],[18.659363,43.058394],[18.659272,43.060441],[18.659001,43.062693],[18.65855,43.064604],[18.657918,43.06515],[18.65846,43.067539],[18.658369,43.070132],[18.658189,43.07177],[18.658369,43.074363],[18.658189,43.077844],[18.657647,43.083985],[18.657376,43.088899],[18.657376,43.09081],[18.657015,43.094359],[18.656654,43.098863],[18.656383,43.102207],[18.656021,43.105414],[18.655299,43.109577],[18.654577,43.11374],[18.653944,43.117903],[18.653222,43.12227],[18.6525,43.125751],[18.651596,43.130937],[18.651145,43.133121],[18.650423,43.137966],[18.649881,43.141856],[18.649339,43.144108],[18.648797,43.147043],[18.650332,43.15025],[18.652138,43.154208],[18.652951,43.156256],[18.653764,43.157825],[18.654757,43.160009],[18.656473,43.163694],[18.657376,43.166765],[18.658189,43.169904],[18.659001,43.172225],[18.659724,43.175023],[18.660717,43.178298],[18.661711,43.181847],[18.662975,43.185942],[18.663607,43.189013],[18.664691,43.191947],[18.665684,43.195223],[18.666497,43.198157],[18.6674,43.201774],[18.668032,43.203685],[18.675437,43.207029],[18.680584,43.209417],[18.682571,43.210168],[18.684919,43.211669],[18.687718,43.213239],[18.691872,43.215764],[18.696207,43.218494],[18.699909,43.220814],[18.703702,43.223339],[18.707946,43.225932],[18.713274,43.229208],[18.717157,43.23187],[18.714268,43.234599],[18.70903,43.238967],[18.704154,43.242584],[18.70018,43.245928],[18.696749,43.248589],[18.694942,43.250022],[18.688421,43.254686],[18.699018,43.260582],[18.70618,43.264631],[18.714507,43.269515],[18.720271,43.272903],[18.725978,43.276423],[18.730228,43.279064],[18.731859,43.28012],[18.73279,43.280516],[18.734013,43.281176],[18.73838,43.282936],[18.743329,43.285004],[18.752005,43.288612],[18.759225,43.291692],[18.767668,43.295213],[18.772268,43.297193],[18.778091,43.299525],[18.785427,43.302209],[18.787465,43.303089],[18.789853,43.304057],[18.79684,43.306389],[18.802197,43.308281],[18.806913,43.309866],[18.810989,43.311318],[18.815939,43.31299],[18.821703,43.31497],[18.826186,43.316466],[18.827642,43.317038],[18.831602,43.318182],[18.83626,43.319502],[18.841151,43.321174],[18.846275,43.323154],[18.852971,43.325707],[18.852738,43.326763],[18.852971,43.327643],[18.852796,43.328611],[18.851865,43.329447],[18.851166,43.330327],[18.8507,43.331119],[18.850642,43.331955],[18.850642,43.333187],[18.850525,43.334375],[18.850118,43.335563],[18.849768,43.336487],[18.848953,43.337147],[18.847963,43.337895],[18.847556,43.338599],[18.847032,43.339259],[18.845984,43.339963],[18.844586,43.340667],[18.84249,43.341724],[18.841384,43.342692],[18.839229,43.344144],[18.839229,43.34476],[18.839753,43.345772],[18.839986,43.347004],[18.839928,43.348324],[18.843363,43.348368],[18.845052,43.348544],[18.846974,43.348852],[18.849477,43.349248],[18.85233,43.349952],[18.854892,43.350656],[18.855708,43.351096],[18.857513,43.351096],[18.858619,43.351272],[18.860133,43.351844],[18.861414,43.351888],[18.862113,43.352108],[18.86287,43.35268],[18.863161,43.353384],[18.863627,43.35378],[18.864733,43.354044],[18.865956,43.354],[18.868285,43.353912],[18.869973,43.353912],[18.871138,43.353868],[18.872361,43.354044],[18.873875,43.354616],[18.876204,43.35554],[18.877252,43.35598],[18.878358,43.356288],[18.879057,43.35642],[18.880629,43.356376],[18.882259,43.356332],[18.883133,43.356244],[18.884297,43.355848],[18.885695,43.355496],[18.886917,43.35532],[18.888082,43.355364],[18.889596,43.355628],[18.891052,43.35576],[18.891925,43.355672],[18.892915,43.3551],[18.893439,43.354572],[18.894254,43.354396],[18.895419,43.35422],[18.896525,43.354132],[18.898039,43.354396],[18.900059,43.3553],[18.901613,43.355979],[18.902079,43.356993],[18.902721,43.35761],[18.903654,43.357962],[18.904762,43.358447],[18.905637,43.358932],[18.907153,43.359372],[18.908669,43.359901],[18.909719,43.360386],[18.910243,43.36043],[18.912459,43.360166],[18.913975,43.359813],[18.914617,43.359461],[18.915083,43.358667],[18.915142,43.357874],[18.91555,43.357301],[18.916775,43.356332],[18.918524,43.355362],[18.919865,43.354745],[18.920798,43.354569],[18.921323,43.353908],[18.922489,43.352013],[18.923131,43.351572],[18.924239,43.351088],[18.926805,43.350118],[18.927738,43.349589],[18.928262,43.348487],[18.928962,43.347033],[18.92972,43.345932],[18.929895,43.344962],[18.930712,43.344257],[18.931645,43.34364],[18.932403,43.343376],[18.934969,43.341481],[18.936718,43.340247],[18.93736,43.339453],[18.937593,43.338704],[18.937943,43.337911],[18.938526,43.337206],[18.939401,43.336897],[18.9401,43.336633],[18.940683,43.336325],[18.941267,43.335531],[18.941558,43.334738],[18.942141,43.334209],[18.942841,43.333945],[18.943949,43.333901],[18.944591,43.33368],[18.94529,43.333196],[18.945698,43.332446],[18.946107,43.331521],[18.946632,43.330948],[18.94739,43.330463],[18.948498,43.330111],[18.949431,43.330287],[18.951297,43.330904],[18.953454,43.331389],[18.955554,43.331389],[18.956312,43.331345],[18.957303,43.331124],[18.958003,43.330728],[18.958586,43.330243],[18.958878,43.329229],[18.959111,43.327731],[18.959344,43.326497],[18.959752,43.325704],[18.960452,43.325131],[18.961093,43.324382],[18.961093,43.323633],[18.960744,43.322884],[18.959985,43.322267],[18.959519,43.321562],[18.959402,43.320856],[18.959519,43.319799],[18.959811,43.318168],[18.959694,43.317022],[18.959286,43.316229],[18.958003,43.3157],[18.956253,43.314863],[18.95497,43.313938],[18.953862,43.313144],[18.952813,43.312175],[18.952055,43.311338],[18.95188,43.31028],[18.951588,43.308297],[18.951005,43.306358],[18.950422,43.305344],[18.950422,43.304551],[18.949197,43.302348],[18.949081,43.301731],[18.949256,43.300893],[18.950714,43.298822],[18.951472,43.297412],[18.952113,43.295958],[18.952988,43.293181],[18.953629,43.292036],[18.953804,43.290802],[18.954679,43.289568],[18.954912,43.288907],[18.955029,43.288202],[18.955612,43.287761],[18.956953,43.287717],[18.958469,43.287849],[18.959519,43.288202],[18.960452,43.288246],[18.961385,43.288069],[18.962726,43.287408],[18.963951,43.287012],[18.966925,43.286747],[18.968383,43.286351],[18.970132,43.285778],[18.972057,43.284588],[18.974214,43.283618],[18.975847,43.283398],[18.977363,43.282957],[18.978879,43.282252],[18.980046,43.281503],[18.981095,43.280886],[18.982087,43.280445],[18.982611,43.279652],[18.983195,43.279344],[18.983661,43.278462],[18.984069,43.276964],[18.984477,43.276083],[18.985702,43.274628],[18.986985,43.273174],[18.98716,43.272205],[18.986985,43.270574],[18.986344,43.268811],[18.98576,43.267754],[18.985352,43.265947],[18.985119,43.264889],[18.984886,43.264184],[18.984652,43.263391],[18.984827,43.26273],[18.985411,43.262069],[18.986985,43.26154],[18.988676,43.260879],[18.990484,43.260174],[18.991825,43.259557],[18.9934,43.25797],[18.995382,43.256516],[18.997015,43.255194],[18.998473,43.254533],[18.999464,43.253696],[18.999989,43.252991],[19.000631,43.25255],[19.001505,43.252462],[19.00273,43.25233],[19.00378,43.252638],[19.004829,43.253431],[19.005412,43.254048],[19.00897,43.258499],[19.012468,43.262333],[19.013343,43.263655],[19.016784,43.269693],[19.018416,43.271984],[19.019641,43.274011],[19.023315,43.281768],[19.025472,43.285954],[19.026405,43.289524],[19.028796,43.296046],[19.030313,43.29988],[19.031012,43.301687],[19.031712,43.302965],[19.032703,43.304287],[19.033636,43.305036],[19.034803,43.305917],[19.036202,43.306578],[19.037777,43.307283],[19.039818,43.307856],[19.04215,43.308429],[19.044425,43.308826],[19.049265,43.309443],[19.051947,43.309663],[19.061336,43.309883],[19.071657,43.309927],[19.075331,43.310192],[19.077897,43.3105],[19.07918,43.311117],[19.080113,43.311866],[19.080754,43.312836],[19.080813,43.313629],[19.080521,43.314687],[19.079355,43.316229],[19.075506,43.321209],[19.07294,43.32469],[19.070666,43.327158],[19.069616,43.328613],[19.068975,43.329979],[19.068742,43.331962],[19.068917,43.334253],[19.069033,43.335399],[19.068625,43.337382],[19.067634,43.339233],[19.066292,43.340467],[19.064485,43.341921],[19.063085,43.34342],[19.062327,43.344654],[19.062036,43.345843],[19.06221,43.347782],[19.062327,43.349325],[19.062152,43.350867],[19.061627,43.352454],[19.060228,43.353732],[19.058653,43.354525],[19.057021,43.355142],[19.052355,43.356332],[19.049498,43.357345],[19.04769,43.358359],[19.045824,43.359901],[19.042267,43.363691],[19.041567,43.364793],[19.040984,43.366996],[19.040576,43.369773],[19.040343,43.372241],[19.039701,43.37418],[19.038535,43.376383],[19.037194,43.378058],[19.035736,43.379688],[19.034103,43.38317],[19.032937,43.388326],[19.031362,43.395641],[19.030954,43.397095],[19.031071,43.398241],[19.032645,43.404323],[19.033053,43.406614],[19.032703,43.408112],[19.032004,43.410404],[19.029496,43.416001],[19.028213,43.418424],[19.023373,43.423713],[19.020457,43.426269],[19.019758,43.427326],[19.018825,43.429574],[19.018591,43.430852],[19.017483,43.431557],[19.016492,43.431733],[19.015792,43.432571],[19.014801,43.432791],[19.014334,43.433187],[19.014334,43.434025],[19.013693,43.43451],[19.011944,43.436404],[19.010661,43.437154],[19.009961,43.437594],[19.009961,43.438784],[19.010544,43.439886],[19.010719,43.440635],[19.010427,43.44112],[19.009728,43.441649],[19.009203,43.441825],[19.008678,43.441384],[19.008328,43.441032],[19.007628,43.441032],[19.007162,43.441472],[19.006929,43.442045],[19.007162,43.442706],[19.007687,43.443367],[19.00862,43.443896],[19.009728,43.444425],[19.010427,43.444866],[19.010894,43.445306],[19.010544,43.445879],[19.009786,43.446056],[19.009203,43.445879],[19.008561,43.446011],[19.008328,43.445549],[19.00757,43.444778],[19.007337,43.444381],[19.00722,43.44394],[19.006608,43.44372],[19.005733,43.444161],[19.005646,43.444822],[19.006287,43.445306],[19.006637,43.445703],[19.00652,43.446232],[19.00617,43.446673],[19.005354,43.446717],[19.004654,43.446628],[19.004363,43.44632],[19.003896,43.445967],[19.003546,43.445395],[19.003488,43.444689],[19.004071,43.444028],[19.004363,43.443411],[19.004071,43.442222],[19.003546,43.441737],[19.002555,43.441384],[19.001855,43.440591],[19.00133,43.439666],[19.000747,43.439181],[18.999931,43.43896],[18.999231,43.439049],[18.998473,43.439798],[18.998123,43.440944],[18.997831,43.442089],[18.99789,43.443147],[18.998181,43.443764],[18.998006,43.444557],[18.996957,43.445306],[18.995557,43.445791],[18.994566,43.446144],[18.993924,43.446761],[18.993283,43.447774],[18.9927,43.448171],[18.99165,43.448039],[18.991067,43.447554],[18.990542,43.447025],[18.989842,43.446673],[18.989609,43.4461],[18.989201,43.445703],[18.988734,43.445659],[18.98821,43.446011],[18.98821,43.446849],[18.988326,43.447862],[18.98786,43.44892],[18.986868,43.449845],[18.986285,43.450418],[18.985935,43.451102],[18.986344,43.451432],[18.98681,43.4513],[18.987452,43.451432],[18.987918,43.451784],[18.987743,43.452269],[18.987277,43.452534],[18.986519,43.452578],[18.985469,43.452401],[18.984536,43.452181],[18.983544,43.452093],[18.982903,43.452401],[18.982378,43.453503],[18.981912,43.4539],[18.981212,43.4539],[18.980687,43.453547],[18.980046,43.453371],[18.979462,43.453459],[18.978413,43.454913],[18.978063,43.455574],[18.977538,43.455971],[18.977013,43.455707],[18.976547,43.455134],[18.976255,43.454385],[18.975847,43.453812],[18.975322,43.453371],[18.974214,43.453107],[18.973165,43.452974],[18.97194,43.453062],[18.970774,43.453151],[18.969841,43.453062],[18.969199,43.453107],[18.968499,43.452974],[18.965875,43.452225],[18.964651,43.451652],[18.962843,43.450815],[18.961735,43.451212],[18.960452,43.452181],[18.959402,43.452974],[18.958878,43.453195],[18.957653,43.453062],[18.956837,43.452666],[18.956137,43.452269],[18.955729,43.453107],[18.955554,43.453635],[18.956137,43.454517],[18.955903,43.45531],[18.955903,43.456368],[18.955962,43.457117],[18.956545,43.457602],[18.957595,43.457998],[18.958586,43.458439],[18.959461,43.459232],[18.960044,43.459805],[18.960802,43.460334],[18.960977,43.460951],[18.960452,43.461568],[18.96016,43.462449],[18.960452,43.463727],[18.96051,43.464873],[18.960277,43.465754],[18.960569,43.466856],[18.960744,43.467473],[18.960335,43.46809],[18.960219,43.468795],[18.960744,43.46928],[18.961735,43.469588],[18.961793,43.470073],[18.960627,43.471263],[18.960569,43.4721],[18.959985,43.472805],[18.958878,43.473687],[18.957886,43.474568],[18.95707,43.475405],[18.956487,43.476022],[18.95672,43.47686],[18.95707,43.477477],[18.957128,43.478754],[18.956953,43.47968],[18.957303,43.480694],[18.957944,43.48131],[18.958994,43.482148],[18.959461,43.482897],[18.959286,43.483602],[18.959169,43.484175],[18.959402,43.485012],[18.959286,43.485717],[18.958819,43.486334],[18.958469,43.487172],[18.958469,43.487833],[18.958003,43.48867],[18.95707,43.489595],[18.95637,43.4903],[18.95602,43.491138],[18.955495,43.492107],[18.953921,43.492812],[18.952638,43.493209],[18.951647,43.493341],[18.95083,43.493341],[18.949955,43.493429],[18.949197,43.494046],[18.948498,43.495148],[18.947856,43.495941],[18.947448,43.49647],[18.947156,43.497396],[18.946573,43.49788],[18.94564,43.498233],[18.944707,43.498629],[18.943891,43.499114],[18.942375,43.499335],[18.941267,43.499379],[18.940042,43.499202],[18.938876,43.498806],[18.938351,43.498541],[18.938642,43.494355],[18.939167,43.491182],[18.938934,43.489375],[18.938234,43.486863],[18.93736,43.485277],[18.936427,43.484439],[18.935085,43.483602],[18.933219,43.482809],[18.931411,43.482324],[18.929545,43.481399],[18.927621,43.480561],[18.926688,43.480297],[18.925872,43.480782],[18.925288,43.4825],[18.924589,43.484131],[18.923422,43.486026],[18.918874,43.492636],[18.918582,43.493914],[18.919049,43.495368],[18.91969,43.496338],[18.920915,43.496999],[18.921556,43.497572],[18.921848,43.498497],[18.921673,43.499246],[18.920332,43.499467],[18.918874,43.499379],[18.918291,43.499555],[18.917941,43.499863],[18.917024,43.501085],[18.915796,43.502322],[18.915387,43.503117],[18.915387,43.503957],[18.916088,43.504885],[18.917608,43.50621],[18.920064,43.507889],[18.921292,43.509038],[18.921935,43.510452],[18.922285,43.511777],[18.922987,43.512396],[18.924156,43.51297],[18.925735,43.513677],[18.92708,43.514295],[18.928132,43.514516],[18.93047,43.514649],[18.934972,43.514737],[18.938363,43.514826],[18.939533,43.516239],[18.94076,43.517697],[18.94152,43.518183],[18.942456,43.518404],[18.9438,43.518449],[18.945262,43.518095],[18.946548,43.517874],[18.948361,43.518139],[18.950524,43.518714],[18.951752,43.519332],[18.95333,43.519597],[18.953915,43.520172],[18.954733,43.52132],[18.955669,43.522204],[18.95678,43.522778],[18.957774,43.523088],[18.959411,43.52322],[18.961515,43.523309],[18.963035,43.523397],[18.964555,43.523795],[18.966251,43.524722],[18.967362,43.525253],[18.96935,43.525518],[18.971688,43.526136],[18.974787,43.526755],[18.978412,43.527373],[18.97999,43.527771],[18.980867,43.528301],[18.981276,43.529494],[18.981569,43.531792],[18.981627,43.533647],[18.981276,43.536387],[18.980926,43.539126],[18.980575,43.541998],[18.98075,43.542837],[18.981276,43.543544],[18.982095,43.544251],[18.983557,43.544914],[18.984667,43.545577],[18.985194,43.546151],[18.985837,43.54783],[18.987591,43.549862],[18.988701,43.551895],[18.989754,43.553485],[18.990923,43.555694],[18.991332,43.556976],[18.992385,43.557197],[18.99677,43.557152],[18.997997,43.557462],[18.999517,43.558389],[19.000687,43.558699],[19.001739,43.558699],[19.002675,43.558301],[19.003084,43.558169],[19.003785,43.558434],[19.004253,43.558257],[19.004955,43.558655],[19.00589,43.558478],[19.006767,43.558743],[19.008579,43.558345],[19.0101,43.557594],[19.010918,43.556976],[19.011503,43.556224],[19.012087,43.554413],[19.01273,43.552999],[19.013023,43.551895],[19.013958,43.550525],[19.014426,43.549685],[19.015244,43.546769],[19.015829,43.545311],[19.016823,43.545621],[19.017525,43.545577],[19.018168,43.545488],[19.019279,43.54593],[19.020155,43.546814],[19.021266,43.547697],[19.022669,43.548095],[19.024014,43.548095],[19.025534,43.547255],[19.02682,43.545753],[19.027931,43.544251],[19.02875,43.542572],[19.028867,43.541202],[19.029393,43.539965],[19.030504,43.539038],[19.032492,43.538242],[19.033836,43.537314],[19.035707,43.53621],[19.03752,43.535194],[19.041671,43.530643],[19.045471,43.527152],[19.04588,43.526004],[19.045178,43.524899],[19.044126,43.523883],[19.043658,43.523088],[19.043249,43.521409],[19.043483,43.519376],[19.043775,43.517918],[19.044535,43.517035],[19.045646,43.516372],[19.046172,43.515356],[19.04664,43.51403],[19.046757,43.511998],[19.046172,43.509391],[19.045646,43.508463],[19.045705,43.506829],[19.045938,43.505503],[19.04664,43.504796],[19.047634,43.504708],[19.048394,43.50515],[19.049154,43.505547],[19.049973,43.505812],[19.050499,43.505591],[19.05085,43.504664],[19.051317,43.503471],[19.052253,43.502675],[19.05348,43.502013],[19.054533,43.501703],[19.055585,43.501969],[19.056696,43.502896],[19.057456,43.503692],[19.058099,43.504178],[19.060028,43.504752],[19.06225,43.505591],[19.063419,43.506254],[19.064413,43.507226],[19.064706,43.508021],[19.064764,43.509435],[19.065173,43.510672],[19.066401,43.5116],[19.067746,43.512528],[19.0695,43.513058],[19.071312,43.5135],[19.073008,43.5135],[19.07406,43.513544],[19.075112,43.514074],[19.076106,43.515002],[19.076925,43.515179],[19.078211,43.515002],[19.07903,43.515135],[19.079907,43.515621],[19.080959,43.516239],[19.082187,43.516505],[19.083824,43.516549],[19.085344,43.516416],[19.086455,43.516549],[19.087916,43.516814],[19.089495,43.517344],[19.091541,43.51973],[19.092535,43.520569],[19.093587,43.521276],[19.094055,43.522381],[19.09423,43.523176],[19.095049,43.523927],[19.096218,43.524413],[19.097855,43.524943],[19.099492,43.525208],[19.101129,43.524811],[19.102123,43.524148],[19.102883,43.523264],[19.104637,43.523176],[19.113056,43.523176],[19.114752,43.522999],[19.116681,43.523088],[19.117967,43.522778],[19.121767,43.521453],[19.122937,43.521232],[19.124223,43.521144],[19.125626,43.521232],[19.127321,43.521585],[19.129192,43.522248],[19.130245,43.523353],[19.130771,43.524855],[19.131706,43.525429],[19.133168,43.526136],[19.13422,43.526799],[19.135799,43.527197],[19.137904,43.52755],[19.139599,43.528301],[19.142522,43.530996],[19.143516,43.531703],[19.145387,43.532631],[19.148837,43.533603],[19.151526,43.534575],[19.153104,43.535149],[19.154157,43.536122],[19.155268,43.536828],[19.156788,43.537094],[19.158834,43.536784],[19.160822,43.536166],[19.164447,43.535768],[19.168188,43.535591],[19.170878,43.535415],[19.173275,43.534487],[19.176198,43.534133],[19.180641,43.534001],[19.183448,43.533912],[19.185611,43.534045],[19.188242,43.534575],[19.190405,43.53484],[19.192977,43.534663],[19.194614,43.534575],[19.197421,43.535105],[19.198765,43.535194],[19.200169,43.535194],[19.202236,43.534788],[19.204459,43.53408],[19.206213,43.533373],[19.207851,43.532489],[19.209547,43.531517],[19.211009,43.530633],[19.211652,43.530456],[19.212939,43.530633],[19.214752,43.530942],[19.215746,43.530854],[19.217894,43.528859],[19.218799,43.527288],[19.219282,43.526644],[19.219894,43.525839],[19.220215,43.525099],[19.220376,43.524069],[19.220344,43.522943],[19.220055,43.521817],[19.219765,43.520851],[19.219508,43.519403],[19.219443,43.518502],[19.219636,43.517408],[19.21999,43.516539],[19.220087,43.51612],[19.220119,43.515638],[19.22028,43.515251],[19.220698,43.514769],[19.221374,43.514254],[19.222114,43.513578],[19.22279,43.513063],[19.223208,43.512677],[19.223498,43.511936],[19.223788,43.511132],[19.223949,43.510392],[19.223981,43.509716],[19.224013,43.508911],[19.224109,43.507978],[19.224721,43.507495],[19.225107,43.506884],[19.225268,43.506272],[19.225268,43.505307],[19.224978,43.504374],[19.224689,43.503601],[19.224657,43.503086],[19.225077,43.502441],[19.225634,43.501765],[19.226669,43.500252],[19.22642,43.499447],[19.226634,43.498376],[19.226629,43.496709],[19.226277,43.495592],[19.225635,43.494521],[19.22485,43.493165],[19.224492,43.491809],[19.224278,43.490738],[19.224278,43.490167],[19.22485,43.489096],[19.225563,43.487883],[19.22592,43.486955],[19.226206,43.485812],[19.225492,43.484813],[19.224635,43.483385],[19.224064,43.482029],[19.223565,43.480958],[19.223565,43.480102],[19.223779,43.479388],[19.224707,43.478817],[19.226991,43.477817],[19.229989,43.476747],[19.234129,43.475176],[19.238484,43.473106],[19.24191,43.471464],[19.245194,43.46918],[19.247621,43.468109],[19.250119,43.466539],[19.251833,43.465111],[19.253189,43.463826],[19.254117,43.462613],[19.254617,43.461756],[19.255116,43.461256],[19.258043,43.460543],[19.25997,43.460043],[19.263825,43.459115],[19.266038,43.458829],[19.267822,43.458615],[19.268965,43.45833],[19.271035,43.457116],[19.272962,43.455831],[19.275318,43.454475],[19.277317,43.453119],[19.278816,43.451548],[19.279672,43.450834],[19.281171,43.449621],[19.284384,43.447765],[19.286954,43.446623],[19.28988,43.445552],[19.292521,43.444767],[19.295912,43.444291],[19.298477,43.444004],[19.300588,43.443482],[19.304228,43.441769],[19.307693,43.440557],[19.309784,43.440054],[19.311795,43.439841],[19.31485,43.440252],[19.318077,43.440912],[19.320718,43.441555],[19.322571,43.441733],[19.323954,43.441515],[19.325603,43.440611],[19.326786,43.439913],[19.328213,43.439127],[19.331067,43.438187],[19.334067,43.436486],[19.33578,43.433916],[19.337922,43.430419],[19.34092,43.426421],[19.342704,43.424208],[19.344489,43.423066],[19.345917,43.422709],[19.34763,43.422495],[19.349343,43.422209],[19.350699,43.421853],[19.351698,43.420996],[19.352698,43.419854],[19.35384,43.41864],[19.35541,43.416927],[19.356767,43.414928],[19.357623,43.413643],[19.35898,43.412287],[19.359857,43.411689],[19.361377,43.411401],[19.363049,43.411787],[19.364762,43.412573],[19.366118,43.413858],[19.366475,43.414928],[19.366975,43.415428],[19.368117,43.415428],[19.370972,43.415428],[19.374399,43.415428],[19.37704,43.415285],[19.379039,43.415142],[19.380548,43.414927],[19.381394,43.414357],[19.381894,43.413572],[19.382394,43.412644],[19.383036,43.411859],[19.384821,43.410645],[19.385749,43.410003],[19.386677,43.409503],[19.388033,43.408361],[19.390032,43.40622],[19.391816,43.404364],[19.393101,43.40315],[19.394101,43.402365],[19.395528,43.401936],[19.396742,43.401794],[19.397813,43.40158],[19.398241,43.400437],[19.398812,43.399295],[19.399312,43.398724],[19.402096,43.397439],[19.404808,43.396368],[19.408806,43.395298],[19.411947,43.394798],[19.41623,43.394013],[19.420156,43.393442],[19.425581,43.393013],[19.429864,43.392514],[19.433219,43.391943],[19.437288,43.391157],[19.439786,43.390444],[19.442142,43.389087],[19.443855,43.388302],[19.445283,43.387802],[19.446354,43.387089],[19.447496,43.385732],[19.448281,43.384376],[19.448923,43.382806],[19.449494,43.381449],[19.449923,43.38045],[19.450208,43.379236],[19.450351,43.37838],[19.450351,43.377024],[19.450351,43.375524],[19.450208,43.373312],[19.450137,43.369742],[19.450066,43.3686],[19.450208,43.367672],[19.450779,43.367173],[19.452207,43.366887],[19.45392,43.36653],[19.455348,43.365959],[19.456847,43.365317],[19.45806,43.364389],[19.458631,43.363603],[19.458989,43.36239],[19.459131,43.361033],[19.458774,43.359749],[19.458203,43.35775],[19.45649,43.352753],[19.456561,43.351825],[19.457632,43.350611],[19.460059,43.348541],[19.461344,43.347399],[19.462629,43.346471],[19.463914,43.345615],[19.465556,43.345186],[19.467126,43.344544],[19.468625,43.343973],[19.470196,43.343045],[19.47198,43.342045],[19.473693,43.341117],[19.475264,43.339975],[19.47662,43.33869],[19.477548,43.337548],[19.478272,43.336506],[19.478976,43.335335],[19.479547,43.333479],[19.480332,43.33198],[19.481546,43.330767],[19.483402,43.329268],[19.485329,43.328268],[19.487399,43.327626],[19.490255,43.326983],[19.491968,43.326769],[19.494252,43.326769],[19.496465,43.326484],[19.498678,43.32577],[19.499959,43.325459],[19.501034,43.325199],[19.502818,43.324485],[19.504389,43.323628],[19.505959,43.3232],[19.507744,43.322915],[19.509243,43.322343],[19.510599,43.321772],[19.511812,43.321273],[19.512741,43.320416],[19.51374,43.319631],[19.514811,43.318846],[19.515882,43.31856],[19.517095,43.318417],[19.518451,43.318846],[19.519308,43.318988],[19.520307,43.318703],[19.521378,43.318346],[19.522734,43.317775],[19.524233,43.317632],[19.526089,43.317561],[19.527374,43.317489],[19.528159,43.317204],[19.528741,43.316498],[19.529016,43.315491],[19.529516,43.314777],[19.530515,43.314134],[19.532442,43.313278],[19.534155,43.31235],[19.535726,43.310779],[19.53694,43.309209],[19.538082,43.307424],[19.538796,43.30564],[19.539055,43.304259],[19.539081,43.303427],[19.53694,43.302213],[19.534013,43.300072],[19.532799,43.299501],[19.5313,43.299001],[19.530515,43.29843],[19.529873,43.297573],[19.529373,43.296574],[19.529444,43.295575],[19.529873,43.294575],[19.530586,43.293576],[19.530789,43.29293],[19.531015,43.291863],[19.530729,43.290935],[19.529944,43.290007],[19.528944,43.288864],[19.528088,43.287865],[19.526798,43.286234],[19.526038,43.284582],[19.525375,43.282797],[19.525375,43.281512],[19.52666,43.280298],[19.52873,43.278585],[19.529873,43.277229],[19.530444,43.276015],[19.530658,43.272946],[19.532014,43.272375],[19.533156,43.271661],[19.53437,43.270019],[19.535655,43.268163],[19.536511,43.266878],[19.538225,43.265022],[19.540295,43.262595],[19.541865,43.26131],[19.542436,43.259597],[19.543721,43.255314],[19.544578,43.253101],[19.544954,43.250069],[19.544595,43.248122],[19.547362,43.24723],[19.549682,43.24607],[19.55102,43.245535],[19.552805,43.245088],[19.554411,43.245267],[19.556641,43.245713],[19.559497,43.246338],[19.561638,43.246516],[19.563601,43.247319],[19.565297,43.248033],[19.566725,43.24839],[19.567974,43.248211],[19.569312,43.248122],[19.57074,43.247676],[19.572346,43.246962],[19.574934,43.246248],[19.576808,43.245891],[19.578771,43.245535],[19.580287,43.245445],[19.581715,43.245535],[19.583321,43.244821],[19.585373,43.24375],[19.587604,43.242501],[19.590638,43.240091],[19.593494,43.237861],[19.595457,43.23563],[19.597509,43.234024],[19.600186,43.232685],[19.602773,43.231615],[19.605629,43.231258],[19.609287,43.230722],[19.613213,43.230009],[19.618121,43.229205],[19.619638,43.228938],[19.621244,43.228313],[19.622761,43.226975],[19.625081,43.224922],[19.627044,43.223138],[19.628025,43.221889],[19.629275,43.219747],[19.629631,43.217695],[19.630256,43.215643],[19.63097,43.214393],[19.632398,43.212698],[19.635164,43.20904],[19.636591,43.206452],[19.636996,43.205366],[19.637394,43.203507],[19.63711,43.202071],[19.636502,43.200473],[19.635875,43.198121],[19.636324,43.196637],[19.637216,43.195655],[19.638465,43.194674],[19.639959,43.192707],[19.640607,43.191283],[19.64141,43.189944],[19.642124,43.189498],[19.646228,43.188427],[19.650154,43.187624],[19.652831,43.18691],[19.659167,43.186286],[19.662736,43.185929],[19.664342,43.18584],[19.666484,43.185661],[19.668893,43.185215],[19.671302,43.184323],[19.6738,43.183431],[19.67612,43.182449],[19.67853,43.181111],[19.679779,43.18004],[19.680403,43.179326],[19.68076,43.178077],[19.680582,43.177095],[19.6796,43.175489],[19.679868,43.174597],[19.680135,43.172991],[19.680493,43.172634],[19.681742,43.172009],[19.683437,43.171117],[19.685311,43.170225],[19.687542,43.168797],[19.688345,43.169154],[19.689505,43.169332],[19.690754,43.1696],[19.692003,43.169511],[19.693431,43.169154],[19.696197,43.169422],[19.699052,43.169957],[19.700569,43.170314],[19.7028,43.170581],[19.705834,43.170671],[19.709849,43.170938],[19.713775,43.171028],[19.716095,43.171117],[19.718683,43.171206],[19.720378,43.171206],[19.722163,43.171563],[19.724126,43.171741],[19.726446,43.171831],[19.72823,43.171831],[19.729123,43.171028],[19.731978,43.168797],[19.734655,43.166388],[19.736618,43.164246],[19.738938,43.161658],[19.740187,43.159874],[19.741169,43.158892],[19.74215,43.159428],[19.743043,43.159695],[19.74456,43.159606],[19.746344,43.159428],[19.749199,43.159339],[19.751966,43.15916],[19.753572,43.159071],[19.754553,43.159517],[19.755535,43.160142],[19.756248,43.161569],[19.758033,43.16264],[19.760442,43.163711],[19.762316,43.164157],[19.76535,43.164871],[19.767313,43.165495],[19.770347,43.166298],[19.770704,43.164425],[19.771418,43.163086],[19.771974,43.16183],[19.772838,43.160784],[19.774221,43.160175],[19.776181,43.159652],[19.777218,43.158868],[19.778485,43.158084],[19.779235,43.156995],[19.779292,43.1546],[19.779868,43.15386],[19.780041,43.153032],[19.780341,43.151665],[19.779805,43.150148],[19.779805,43.14872],[19.779538,43.147471],[19.779062,43.146151],[19.779805,43.144972],[19.780519,43.144169],[19.780876,43.143009],[19.780519,43.141671],[19.779347,43.140385],[19.778946,43.139923],[19.77837,43.139662],[19.777485,43.13944],[19.777039,43.138548],[19.776861,43.137477],[19.776682,43.136585],[19.777753,43.136406],[19.779359,43.13596],[19.781233,43.13489],[19.782571,43.133908],[19.784088,43.133016],[19.784624,43.132302],[19.784891,43.131142],[19.784802,43.129893],[19.785338,43.128733],[19.787836,43.125163],[19.789531,43.12329],[19.790959,43.122397],[19.792565,43.12204],[19.794439,43.12204],[19.795866,43.122219],[19.797294,43.122219],[19.798722,43.121773],[19.799347,43.121505],[19.800774,43.120077],[19.802737,43.117044],[19.804433,43.115081],[19.805682,43.113831],[19.80702,43.11285],[19.80827,43.112136],[19.809697,43.112136],[19.811393,43.11285],[19.81282,43.113207],[19.814783,43.113921],[19.818174,43.115259],[19.821565,43.116508],[19.823439,43.117222],[19.825134,43.117847],[19.827186,43.118114],[19.82906,43.117847],[19.830488,43.11749],[19.832081,43.116546],[19.833789,43.114991],[19.834949,43.113742],[19.83602,43.112225],[19.83602,43.110351],[19.835026,43.109007],[19.833696,43.1075],[19.831891,43.106136],[19.829895,43.1047],[19.831202,43.102767],[19.832366,43.100536],[19.833221,43.099459],[19.834076,43.09831],[19.834235,43.095985],[19.834414,43.093665],[19.834503,43.092505],[19.834592,43.091702],[19.837448,43.090988],[19.838429,43.090899],[19.839321,43.092684],[19.840419,43.094332],[19.841552,43.095271],[19.844319,43.097592],[19.846371,43.098841],[19.848155,43.099733],[19.855074,43.101756],[19.85916,43.103192],[19.861155,43.104054],[19.860201,43.107674],[19.86201,43.107787],[19.863503,43.107764],[19.865823,43.107764],[19.867251,43.107318],[19.86841,43.106871],[19.871623,43.106425],[19.874656,43.105711],[19.876441,43.105176],[19.877958,43.104462],[19.879832,43.103124],[19.88126,43.101785],[19.883133,43.101607],[19.884918,43.10125],[19.886346,43.100536],[19.887506,43.099644],[19.888487,43.098305],[19.88929,43.097324],[19.891085,43.09752],[19.8917,43.097859],[19.892413,43.098216],[19.893395,43.098573],[19.894644,43.098573],[19.895551,43.098669],[19.897451,43.098813],[19.899462,43.098841],[19.900801,43.099019],[19.90205,43.098751],[19.902586,43.098038],[19.903299,43.096967],[19.903746,43.096253],[19.904281,43.095361],[19.905173,43.094022],[19.905976,43.092952],[19.906667,43.091346],[19.907143,43.090843],[19.909278,43.089382],[19.911062,43.088222],[19.913739,43.086616],[19.915256,43.085545],[19.916148,43.085278],[19.917119,43.085674],[19.919361,43.087241],[19.92061,43.088133],[19.922484,43.088401],[19.924625,43.088579],[19.926499,43.089739],[19.929354,43.089828],[19.932745,43.089828],[19.935511,43.090364],[19.938099,43.091792],[19.940597,43.093665],[19.94265,43.095271],[19.944256,43.096788],[19.946384,43.098023],[19.949424,43.09953],[19.95218,43.100966],[19.953415,43.101756],[19.954785,43.103302],[19.955677,43.104551],[19.957015,43.106782],[19.957976,43.1075],[19.959692,43.108567],[19.961209,43.10937],[19.963391,43.110156],[19.965046,43.110619],[19.966652,43.110797],[19.968237,43.110515],[19.969062,43.109816],[19.969865,43.108745],[19.971114,43.107585],[19.972363,43.106514],[19.973938,43.104915],[19.974983,43.103695],[19.975397,43.102678],[19.97504,43.101607],[19.974148,43.100536],[19.973255,43.098484],[19.97272,43.09661],[19.972631,43.095182],[19.972988,43.093665],[19.973969,43.090453],[19.975129,43.087687],[19.975575,43.086259],[19.9762,43.084921],[19.977449,43.084207],[19.979145,43.083493],[19.98084,43.082512],[19.982584,43.081438],[19.983606,43.08037],[19.984105,43.079213],[19.984485,43.078207],[19.9842,43.077059],[19.98344,43.075982],[19.982535,43.075284],[19.981554,43.074302],[19.981197,43.073143],[19.981464,43.071536],[19.982089,43.069484],[19.983249,43.067075],[19.984231,43.065647],[19.986005,43.065213],[19.9878,43.063952],[19.988692,43.063149],[19.988692,43.062346],[19.988157,43.06065],[19.988068,43.059044],[19.988285,43.057961],[19.989425,43.056238],[19.991421,43.054515],[19.992656,43.053438],[19.994461,43.052218],[19.995982,43.051572],[19.998547,43.050136],[20.000542,43.048628],[20.001631,43.048158],[20.003108,43.047407],[20.005008,43.047407],[20.006199,43.04669],[20.006855,43.046653],[20.007652,43.046383],[20.00816,43.045903],[20.008816,43.045633],[20.009687,43.04547],[20.010288,43.045123],[20.010549,43.044681],[20.010819,43.04434],[20.011074,43.043749],[20.011445,43.043286],[20.011875,43.042858],[20.012202,43.042543],[20.012646,43.042297],[20.013059,43.041788],[20.013887,43.041605],[20.014392,43.041227],[20.014996,43.041013],[20.015655,43.040696],[20.016422,43.040789],[20.017308,43.040779],[20.017919,43.040422],[20.018691,43.04033],[20.019366,43.040266],[20.019821,43.040304],[20.020278,43.04035],[20.02087,43.040371],[20.021469,43.040249],[20.022012,43.039984],[20.022717,43.039531],[20.023443,43.03911],[20.023917,43.038886],[20.024513,43.038807],[20.025199,43.038792],[20.026015,43.038611],[20.026833,43.038438],[20.027651,43.038324],[20.028481,43.038325],[20.029207,43.038197],[20.02966,43.038109],[20.030241,43.03773],[20.031171,43.036958],[20.032151,43.036244],[20.033105,43.035523],[20.03359,43.035816],[20.034108,43.036022],[20.034938,43.035907],[20.03569,43.035901],[20.03611,43.035717],[20.036534,43.035147],[20.036813,43.034729],[20.037339,43.03439],[20.037691,43.033662],[20.037984,43.033309],[20.038582,43.032945],[20.039344,43.032519],[20.040013,43.032247],[20.040357,43.031838],[20.040764,43.03148],[20.041346,43.031218],[20.041465,43.030768],[20.041756,43.03029],[20.04173,43.029436],[20.042172,43.029036],[20.04281,43.028859],[20.04364,43.028568],[20.044494,43.028617],[20.045107,43.028326],[20.045571,43.027994],[20.045829,43.027478],[20.046321,43.02716],[20.046751,43.026967],[20.047489,43.026485],[20.047798,43.025679],[20.047835,43.02503],[20.048085,43.024657],[20.048571,43.024482],[20.049254,43.024275],[20.04933,43.023454],[20.049513,43.022947],[20.049637,43.022405],[20.049661,43.021875],[20.049859,43.021374],[20.050732,43.021162],[20.051653,43.020876],[20.052426,43.020265],[20.053412,43.019637],[20.054731,43.018601],[20.05517,43.018331],[20.055734,43.018046],[20.056198,43.017539],[20.055966,43.016713],[20.055618,43.015818],[20.055057,43.014889],[20.054415,43.013877],[20.054196,43.01264],[20.054109,43.011713],[20.054142,43.01099],[20.05403,43.010593],[20.054035,43.009622],[20.054525,43.009237],[20.055348,43.008854],[20.055964,43.008572],[20.056669,43.008295],[20.057069,43.008021],[20.056973,43.007522],[20.05719,43.00717],[20.057936,43.006437],[20.058551,43.006037],[20.058876,43.005597],[20.059216,43.005221],[20.059992,43.005527],[20.060921,43.006014],[20.061451,43.006101],[20.062097,43.006485],[20.062931,43.006385],[20.064079,43.006206],[20.065074,43.005853],[20.06565,43.005505],[20.065549,43.004868],[20.065599,43.004159],[20.065851,43.00356],[20.066112,43.002914],[20.065857,43.002245],[20.06596,43.001723],[20.065836,43.001269],[20.066111,43.000952],[20.066408,43.000556],[20.066836,43.000237],[20.067279,42.999925],[20.067574,42.999405],[20.068146,42.999044],[20.068831,42.998903],[20.069405,42.999136],[20.069843,42.999385],[20.070394,42.999571],[20.070982,42.999693],[20.071656,42.999797],[20.072426,42.999813],[20.07299,42.999997],[20.073622,42.999704],[20.074479,42.999217],[20.075466,42.999058],[20.076295,42.999051],[20.077015,42.998664],[20.077671,42.998393],[20.078115,42.997855],[20.07839,42.997244],[20.079054,42.996366],[20.078951,42.995769],[20.078854,42.995319],[20.079213,42.994916],[20.079457,42.994509],[20.079808,42.993947],[20.080442,42.993755],[20.081122,42.993658],[20.081836,42.993658],[20.082689,42.993532],[20.083162,42.993829],[20.083625,42.993967],[20.084028,42.994297],[20.084355,42.994628],[20.084841,42.994697],[20.085497,42.994955],[20.085926,42.995173],[20.086725,42.995297],[20.08719,42.994881],[20.087723,42.994457],[20.087905,42.993941],[20.087788,42.993459],[20.087245,42.992894],[20.0871,42.992399],[20.087401,42.992078],[20.087839,42.991925],[20.088607,42.991583],[20.089407,42.991329],[20.089956,42.991273],[20.090127,42.990648],[20.09014,42.990059],[20.089858,42.989404],[20.090106,42.989014],[20.091284,42.98874],[20.092313,42.988543],[20.092871,42.98841],[20.093567,42.988446],[20.09437,42.988267],[20.09496,42.987929],[20.095444,42.987511],[20.0961,42.987123],[20.096598,42.986594],[20.096858,42.986202],[20.097274,42.985708],[20.097866,42.985202],[20.098632,42.98491],[20.098787,42.984506],[20.099139,42.984128],[20.099898,42.983745],[20.099906,42.982779],[20.09967,42.982278],[20.099586,42.981708],[20.099826,42.981227],[20.100209,42.980812],[20.100675,42.98043],[20.101344,42.97999],[20.101621,42.979437],[20.101693,42.978648],[20.102148,42.977922],[20.10276,42.976566],[20.102715,42.975648],[20.102826,42.97498],[20.103175,42.97441],[20.103593,42.973865],[20.104555,42.973181],[20.105661,42.97216],[20.106342,42.971652],[20.107092,42.97158],[20.107896,42.97141],[20.108545,42.971342],[20.109089,42.971378],[20.11014,42.971582],[20.110995,42.971552],[20.111333,42.970963],[20.111188,42.970409],[20.111691,42.969904],[20.112031,42.969646],[20.112502,42.969465],[20.112953,42.969428],[20.113449,42.969185],[20.113953,42.968983],[20.114221,42.968418],[20.114743,42.967975],[20.115207,42.967819],[20.11595,42.967597],[20.116654,42.967254],[20.117221,42.966515],[20.117444,42.966011],[20.117347,42.96556],[20.117778,42.965316],[20.118303,42.965381],[20.11885,42.965492],[20.119319,42.965361],[20.119657,42.965095],[20.119943,42.964591],[20.120771,42.964586],[20.12113,42.964241],[20.121539,42.96374],[20.121948,42.964128],[20.122285,42.964567],[20.122673,42.965008],[20.122879,42.965428],[20.123285,42.965657],[20.123801,42.965681],[20.124161,42.966108],[20.124751,42.966627],[20.125547,42.967095],[20.126729,42.9674],[20.127604,42.9677],[20.128179,42.968001],[20.128767,42.968301],[20.129925,42.968526],[20.130582,42.968792],[20.131071,42.969289],[20.1313,42.969639],[20.131927,42.970061],[20.132723,42.970026],[20.133393,42.969879],[20.133808,42.970149],[20.133893,42.97066],[20.133768,42.971086],[20.133817,42.971785],[20.134044,42.972774],[20.134372,42.973172],[20.134995,42.973577],[20.135707,42.973862],[20.136309,42.974169],[20.136474,42.974578],[20.136644,42.975187],[20.136705,42.975885],[20.136554,42.976306],[20.137093,42.977267],[20.137126,42.978069],[20.137567,42.978696],[20.137444,42.97919],[20.137372,42.97992],[20.138173,42.980438],[20.138704,42.980829],[20.139341,42.981299],[20.140128,42.981635],[20.140887,42.982259],[20.141134,42.98275],[20.141281,42.983194],[20.142012,42.983629],[20.142543,42.984019],[20.143056,42.984739],[20.143682,42.98522],[20.144557,42.986082],[20.14524,42.986765],[20.146055,42.987466],[20.146576,42.988404],[20.147034,42.989047],[20.147599,42.989181],[20.148164,42.988964],[20.149214,42.988806],[20.149678,42.988886],[20.15025,42.988466],[20.150972,42.987793],[20.151273,42.986943],[20.151804,42.985739],[20.152329,42.984569],[20.151964,42.983823],[20.151592,42.983162],[20.151717,42.98203],[20.151894,42.981195],[20.15202,42.979888],[20.152354,42.979193],[20.152746,42.97835],[20.152797,42.977639],[20.152848,42.976457],[20.153235,42.974766],[20.153523,42.973914],[20.15406,42.973863],[20.155046,42.973881],[20.15589,42.973773],[20.156562,42.973576],[20.157548,42.9733],[20.158396,42.972974],[20.159061,42.972568],[20.159541,42.972016],[20.160358,42.971844],[20.160972,42.971495],[20.161629,42.97135],[20.162485,42.97124],[20.163082,42.971405],[20.163816,42.971377],[20.164408,42.971047],[20.165195,42.970736],[20.166116,42.970451],[20.166857,42.970456],[20.167389,42.970385],[20.167675,42.970704],[20.167637,42.971296],[20.167859,42.97179],[20.16864,42.972277],[20.169571,42.97257],[20.170327,42.972531],[20.171054,42.972412],[20.171721,42.972132],[20.172355,42.971822],[20.172657,42.971682],[20.173275,42.971408],[20.173798,42.971235],[20.17454,42.970984],[20.175724,42.970791],[20.176537,42.970684],[20.177439,42.970101],[20.178048,42.969425],[20.178785,42.968742],[20.17911,42.968203],[20.17935,42.967809],[20.179601,42.967406],[20.180229,42.966227],[20.180641,42.965847],[20.182549,42.965023],[20.183448,42.964601],[20.184253,42.964283],[20.184831,42.963883],[20.185812,42.963595],[20.186487,42.963047],[20.186743,42.962669],[20.186467,42.961887],[20.186416,42.9613],[20.186408,42.960792],[20.186608,42.960394],[20.187367,42.960048],[20.187981,42.959457],[20.18833,42.959025],[20.188822,42.958651],[20.189591,42.958466],[20.190181,42.958361],[20.190699,42.958281],[20.191181,42.958215],[20.191673,42.958139],[20.192153,42.958004],[20.192914,42.957786],[20.193646,42.957672],[20.194368,42.957628],[20.195043,42.957673],[20.195691,42.957825],[20.196583,42.957904],[20.197702,42.957888],[20.198586,42.957748],[20.199345,42.95752],[20.200215,42.957085],[20.200982,42.956713],[20.20205,42.956525],[20.203106,42.956457],[20.20376,42.956522],[20.204563,42.956969],[20.20514,42.957094],[20.205699,42.957146],[20.206275,42.957212],[20.206819,42.957486],[20.207655,42.957784],[20.208124,42.957957],[20.208892,42.95783],[20.20967,42.957864],[20.210424,42.95785],[20.211275,42.957798],[20.211909,42.957416],[20.212713,42.95698],[20.213288,42.956563],[20.213909,42.956183],[20.214763,42.955732],[20.215536,42.955393],[20.216336,42.95517],[20.21677,42.954888],[20.21713,42.954268],[20.217433,42.95351],[20.217758,42.952911],[20.217814,42.952455],[20.217806,42.952006],[20.21819,42.951345],[20.218627,42.950754],[20.218996,42.950412],[20.219296,42.950054],[20.219975,42.949582],[20.220625,42.949156],[20.220996,42.948823],[20.22129,42.948499],[20.221928,42.948193],[20.222458,42.947815],[20.222829,42.947541],[20.22349,42.946987],[20.223962,42.946582],[20.224364,42.946093],[20.224798,42.945811],[20.225423,42.945685],[20.225804,42.945461],[20.226155,42.945037],[20.226694,42.944522],[20.226978,42.944208],[20.227132,42.943664],[20.227495,42.943238],[20.227896,42.942927],[20.228474,42.942823],[20.229114,42.942823],[20.229599,42.942832],[20.230573,42.942868],[20.231462,42.942812],[20.231994,42.94262],[20.232521,42.942285],[20.232915,42.942],[20.233375,42.941775],[20.233911,42.94166],[20.234452,42.941451],[20.23515,42.941358],[20.23584,42.941233],[20.236792,42.941169],[20.237832,42.941027],[20.238461,42.940798],[20.238899,42.94049],[20.239912,42.940185],[20.240685,42.940012],[20.24133,42.940123],[20.241867,42.940204],[20.242949,42.940193],[20.244272,42.940078],[20.245564,42.939698],[20.246401,42.93951],[20.247369,42.939921],[20.248128,42.940156],[20.249051,42.940437],[20.250363,42.940569],[20.251671,42.94042],[20.252236,42.940099],[20.252754,42.939535],[20.253561,42.938978],[20.254534,42.938607],[20.255307,42.938434],[20.255953,42.938329],[20.25666,42.937842],[20.257239,42.937226],[20.258073,42.937029],[20.259042,42.936923],[20.260004,42.936611],[20.260459,42.936147],[20.260978,42.935394],[20.262092,42.935046],[20.262842,42.935067],[20.264188,42.93506],[20.264923,42.934802],[20.265568,42.934255],[20.266651,42.933698],[20.267859,42.93299],[20.269277,42.932326],[20.270104,42.93247],[20.270509,42.932741],[20.271061,42.93294],[20.271486,42.93268],[20.271887,42.932397],[20.272582,42.932703],[20.273329,42.933073],[20.274563,42.933383],[20.275279,42.9336],[20.275846,42.933532],[20.276485,42.934011],[20.277277,42.934511],[20.277942,42.934203],[20.278179,42.933649],[20.278384,42.932971],[20.278809,42.932193],[20.280374,42.932332],[20.281265,42.932348],[20.282003,42.932314],[20.282402,42.932079],[20.282866,42.931857],[20.283458,42.931516],[20.283733,42.930561],[20.28399,42.928987],[20.284926,42.927314],[20.28551,42.927462],[20.285967,42.92758],[20.286431,42.927658],[20.286898,42.927661],[20.28748,42.927571],[20.288038,42.927345],[20.288744,42.927019],[20.289161,42.926798],[20.289582,42.926558],[20.290027,42.926293],[20.290527,42.926043],[20.291075,42.92582],[20.291783,42.925554],[20.292157,42.924906],[20.292318,42.924455],[20.293039,42.923617],[20.29379,42.92312],[20.294538,42.922755],[20.295072,42.922611],[20.29585,42.922573],[20.296583,42.922405],[20.297143,42.922348],[20.297556,42.922391],[20.298219,42.922169],[20.29869,42.921889],[20.299234,42.921339],[20.300373,42.921023],[20.301277,42.921203],[20.302344,42.921091],[20.30337,42.921129],[20.303744,42.920816],[20.304355,42.920746],[20.304626,42.921094],[20.305194,42.921334],[20.305993,42.921314],[20.306653,42.921139],[20.307179,42.921239],[20.307615,42.921763],[20.307936,42.922062],[20.308507,42.922254],[20.309496,42.922695],[20.309881,42.922978],[20.310098,42.923338],[20.311268,42.92338],[20.311678,42.922796],[20.312118,42.922308],[20.312026,42.921609],[20.311367,42.921297],[20.310741,42.921033],[20.310904,42.920564],[20.310704,42.920162],[20.310448,42.919549],[20.310357,42.918662],[20.310029,42.917804],[20.310529,42.917564],[20.311431,42.917426],[20.314948,42.917184],[20.316974,42.916574],[20.318916,42.915936],[20.320518,42.91596],[20.322351,42.915967],[20.322753,42.915366],[20.323444,42.9148],[20.324112,42.914184],[20.324733,42.913485],[20.325312,42.91288],[20.325894,42.912255],[20.326749,42.912418],[20.327525,42.912862],[20.328369,42.913243],[20.328724,42.913702],[20.329509,42.913759],[20.330996,42.913492],[20.331754,42.913107],[20.332253,42.912455],[20.333117,42.911633],[20.333631,42.911015],[20.334085,42.910262],[20.334405,42.90969],[20.334761,42.909363],[20.335026,42.909019],[20.335575,42.908347],[20.336337,42.907675],[20.337023,42.907883],[20.337515,42.908084],[20.338062,42.90833],[20.338617,42.908404],[20.33902,42.908646],[20.339488,42.909172],[20.340085,42.909396],[20.341019,42.909577],[20.341809,42.909671],[20.342621,42.909601],[20.343173,42.909667],[20.34405,42.909881],[20.344398,42.910295],[20.344746,42.910765],[20.345016,42.911328],[20.345583,42.911213],[20.345851,42.910738],[20.346026,42.910162],[20.346044,42.909578],[20.346222,42.909143],[20.346438,42.908563],[20.345934,42.908078],[20.345826,42.907505],[20.345779,42.906963],[20.346077,42.90664],[20.346535,42.906466],[20.347333,42.906362],[20.3477,42.90614],[20.347328,42.905699],[20.346713,42.905324],[20.346987,42.904703],[20.347092,42.904154],[20.34759,42.903746],[20.348013,42.903328],[20.347736,42.902532],[20.347806,42.901579],[20.347799,42.901047],[20.348284,42.900689],[20.34858,42.900198],[20.34897,42.900059],[20.349357,42.899612],[20.34918,42.898774],[20.349394,42.898339],[20.349399,42.897589],[20.349514,42.897038],[20.34977,42.896593],[20.349901,42.896104],[20.349866,42.895644],[20.349669,42.895138],[20.349175,42.894853],[20.348459,42.894545],[20.347827,42.89416],[20.347584,42.893769],[20.347387,42.893291],[20.347187,42.892833],[20.346835,42.892111],[20.346543,42.891525],[20.346008,42.890491],[20.345443,42.889445],[20.345078,42.888501],[20.344923,42.887714],[20.344973,42.886795],[20.345152,42.885685],[20.345435,42.884729],[20.345674,42.883484],[20.345879,42.882134],[20.346124,42.880738],[20.346269,42.879524],[20.346177,42.878525],[20.346066,42.877512],[20.34594,42.876625],[20.345865,42.876128],[20.34513,42.875467],[20.344562,42.874851],[20.344392,42.874222],[20.343965,42.873276],[20.343293,42.872675],[20.342543,42.871788],[20.342161,42.870835],[20.342137,42.869841],[20.342146,42.869025],[20.342357,42.868157],[20.34303,42.86752],[20.343604,42.866966],[20.344307,42.866324],[20.344411,42.86569],[20.344695,42.865006],[20.344552,42.864339],[20.344497,42.863797],[20.344406,42.863179],[20.344611,42.86229],[20.344878,42.861631],[20.345205,42.860907],[20.345577,42.860463],[20.345976,42.860175],[20.34652,42.859682],[20.347222,42.858978],[20.347623,42.858019],[20.348,42.85731],[20.348277,42.856742],[20.348618,42.855958],[20.348788,42.855165],[20.348867,42.854437],[20.348351,42.8539],[20.347914,42.853539],[20.347554,42.853179],[20.347268,42.852636],[20.347254,42.852019],[20.34738,42.851405],[20.34765,42.850872],[20.347503,42.850275],[20.347501,42.849702],[20.347636,42.849063],[20.347851,42.848607],[20.347975,42.847706],[20.348154,42.847003],[20.348187,42.846334],[20.348534,42.8454],[20.348917,42.844713],[20.349428,42.844271],[20.350149,42.843753],[20.350969,42.843369],[20.351714,42.842767],[20.351764,42.841648],[20.351568,42.840473],[20.351506,42.839963],[20.351723,42.83943],[20.351878,42.838796],[20.351723,42.838226],[20.351583,42.837782],[20.351583,42.837358],[20.351627,42.836927],[20.35182,42.83656],[20.351968,42.836028],[20.352196,42.835365],[20.352465,42.834855],[20.352542,42.834431],[20.352727,42.833894],[20.352911,42.833454],[20.352593,42.833373],[20.352094,42.833291],[20.351468,42.833196],[20.350822,42.833144],[20.35035,42.832962],[20.350047,42.832837],[20.349746,42.832717],[20.349296,42.832627],[20.348941,42.83266],[20.348449,42.832726],[20.347922,42.832801],[20.347395,42.832896],[20.346839,42.832996],[20.346153,42.833085],[20.34539,42.833188],[20.344896,42.833153],[20.344536,42.833148],[20.34419,42.833141],[20.343661,42.833232],[20.343171,42.833506],[20.342607,42.833906],[20.342219,42.834111],[20.341782,42.834272],[20.341437,42.834661],[20.341199,42.83521],[20.340651,42.835665],[20.340122,42.836095],[20.339574,42.836198],[20.339086,42.836146],[20.338691,42.835911],[20.338178,42.835795],[20.337331,42.835779],[20.336619,42.835824],[20.336202,42.835834],[20.335785,42.835846],[20.335232,42.835871],[20.334545,42.835549],[20.33427,42.83528],[20.333812,42.835058],[20.333415,42.834917],[20.333005,42.834746],[20.332476,42.834395],[20.331921,42.834011],[20.331417,42.833676],[20.33107,42.833643],[20.330654,42.833567],[20.330116,42.833473],[20.329514,42.833522],[20.329137,42.833568],[20.328815,42.83359],[20.328331,42.833566],[20.327898,42.833412],[20.327475,42.833144],[20.32715,42.832882],[20.326642,42.83244],[20.326637,42.831832],[20.32671,42.831229],[20.326332,42.830578],[20.325745,42.830056],[20.325345,42.829552],[20.324638,42.829272],[20.323949,42.829127],[20.323208,42.828915],[20.322753,42.828856],[20.322349,42.828698],[20.321799,42.828671],[20.321357,42.82865],[20.321021,42.82862],[20.320525,42.828525],[20.320187,42.828297],[20.319636,42.828116],[20.319214,42.828217],[20.318797,42.828317],[20.318381,42.828417],[20.317825,42.82855],[20.317302,42.828717],[20.316779,42.829047],[20.31657,42.829562],[20.31648,42.830117],[20.316389,42.830673],[20.31631,42.831178],[20.31627,42.831544],[20.316243,42.831913],[20.316263,42.83242],[20.316285,42.832975],[20.316301,42.833392],[20.316297,42.833825],[20.316244,42.834303],[20.31605,42.834795],[20.315831,42.83535],[20.315612,42.835906],[20.315246,42.836041],[20.314829,42.836037],[20.314274,42.836032],[20.313718,42.836026],[20.313301,42.836022],[20.312885,42.836018],[20.31238,42.836021],[20.311874,42.836065],[20.311457,42.836101],[20.310921,42.836023],[20.310417,42.835704],[20.310039,42.835594],[20.309646,42.835533],[20.309171,42.835668],[20.308731,42.835948],[20.308373,42.835819],[20.307975,42.835772],[20.307608,42.835736],[20.307102,42.83572],[20.306425,42.83561],[20.305867,42.835622],[20.305262,42.835728],[20.304693,42.835913],[20.304312,42.835994],[20.303924,42.836077],[20.303397,42.836189],[20.302884,42.836281],[20.302371,42.836302],[20.301816,42.836324],[20.30113,42.836293],[20.300611,42.836263],[20.30009,42.836251],[20.299673,42.836242],[20.299257,42.836233],[20.29884,42.836224],[20.298423,42.836214],[20.298006,42.836205],[20.29801,42.835769],[20.298015,42.835214],[20.29758,42.83456],[20.297238,42.833929],[20.297047,42.833361],[20.296924,42.832944],[20.296751,42.832579],[20.296381,42.832226],[20.295995,42.831856],[20.295526,42.831318],[20.295229,42.830737],[20.295016,42.83032],[20.294804,42.829904],[20.294591,42.829487],[20.294396,42.829105],[20.294202,42.828723],[20.293991,42.828307],[20.293777,42.827735],[20.293771,42.827163],[20.293766,42.826746],[20.293812,42.826214],[20.293859,42.825679],[20.293568,42.825461],[20.293237,42.825342],[20.292686,42.825321],[20.292097,42.825279],[20.291397,42.825465],[20.290887,42.82556],[20.290199,42.825636],[20.289614,42.825659],[20.289149,42.82562],[20.288557,42.825568],[20.288105,42.825562],[20.287767,42.825484],[20.28721,42.825502],[20.286732,42.825638],[20.28633,42.825915],[20.285953,42.826061],[20.285543,42.826049],[20.285183,42.825457],[20.284905,42.824638],[20.284252,42.824414],[20.283663,42.82433],[20.283027,42.824183],[20.282501,42.824009],[20.282008,42.823799],[20.281246,42.82378],[20.280627,42.824177],[20.280202,42.82431],[20.279427,42.824166],[20.278856,42.823923],[20.278169,42.823691],[20.27755,42.82346],[20.277279,42.823126],[20.27731,42.822667],[20.277483,42.822374],[20.277374,42.821919],[20.277053,42.821508],[20.27633,42.821207],[20.275741,42.820893],[20.275483,42.820329],[20.274918,42.820004],[20.274567,42.819811],[20.274108,42.819631],[20.273589,42.819477],[20.273087,42.819309],[20.272495,42.819047],[20.271897,42.818973],[20.271374,42.818755],[20.270868,42.818398],[20.270118,42.817991],[20.269361,42.81796],[20.268884,42.817991],[20.268414,42.817969],[20.267848,42.817883],[20.267397,42.818006],[20.266785,42.818214],[20.266175,42.817925],[20.265755,42.817724],[20.265968,42.817032],[20.265982,42.816403],[20.265202,42.816003],[20.264646,42.815795],[20.264188,42.815682],[20.263526,42.815517],[20.263009,42.815374],[20.262582,42.815245],[20.262191,42.815121],[20.261816,42.814897],[20.261425,42.814623],[20.260862,42.814373],[20.260306,42.814378],[20.259851,42.814515],[20.259512,42.814706],[20.259186,42.814898],[20.258727,42.815219],[20.258043,42.815284],[20.257564,42.815263],[20.257118,42.815051],[20.256633,42.814818],[20.256285,42.814764],[20.255899,42.814698],[20.255514,42.814617],[20.25506,42.81443],[20.254694,42.813916],[20.254265,42.813313],[20.254103,42.812731],[20.253744,42.812295],[20.253387,42.81209],[20.252999,42.811895],[20.252545,42.811684],[20.252274,42.811222],[20.252165,42.81076],[20.252813,42.810498],[20.253251,42.810118],[20.253447,42.809476],[20.253511,42.808882],[20.253819,42.808402],[20.25406,42.808044],[20.254337,42.807644],[20.254894,42.807059],[20.255596,42.806995],[20.255895,42.806731],[20.256019,42.80633],[20.256642,42.806136],[20.257006,42.805944],[20.257437,42.805546],[20.257951,42.805128],[20.258326,42.804819],[20.258683,42.804587],[20.259349,42.804509],[20.259839,42.804307],[20.260248,42.803985],[20.260751,42.803977],[20.261456,42.803963],[20.262106,42.80406],[20.262598,42.80414],[20.26274,42.803761],[20.262696,42.803205],[20.262651,42.80265],[20.262606,42.802094],[20.262558,42.801499],[20.262528,42.801101],[20.262497,42.800684],[20.262456,42.800129],[20.262424,42.799712],[20.262388,42.799268],[20.262344,42.798712],[20.262148,42.798204],[20.261872,42.797823],[20.261776,42.797261],[20.261783,42.796826],[20.261881,42.796357],[20.26205,42.795838],[20.262215,42.795502],[20.262297,42.795069],[20.262427,42.794549],[20.26267,42.794053],[20.262883,42.793632],[20.262934,42.793216],[20.263001,42.79266],[20.263052,42.792243],[20.263103,42.791827],[20.26317,42.791271],[20.263237,42.790716],[20.263309,42.790103],[20.263357,42.789686],[20.263411,42.789292],[20.26335,42.788868],[20.263568,42.788411],[20.263737,42.787946],[20.263845,42.787581],[20.263999,42.787076],[20.264164,42.786532],[20.264329,42.785987],[20.264473,42.785511],[20.264601,42.785095],[20.264805,42.78442],[20.26493,42.784003],[20.265061,42.783571],[20.26523,42.783015],[20.265377,42.782523],[20.265502,42.782107],[20.265626,42.78169],[20.265749,42.781281],[20.265913,42.780732],[20.266079,42.780177],[20.266203,42.77976],[20.266317,42.779414],[20.266216,42.778925],[20.26608,42.778432],[20.265668,42.77789],[20.265282,42.777473],[20.264962,42.777111],[20.264692,42.776749],[20.26425,42.776383],[20.263707,42.775982],[20.263164,42.775744],[20.262656,42.775598],[20.26224,42.775502],[20.261614,42.775336],[20.260984,42.775016],[20.26051,42.774681],[20.260213,42.774157],[20.259897,42.773602],[20.259488,42.773154],[20.259121,42.772769],[20.258733,42.772226],[20.25847,42.771561],[20.258217,42.771117],[20.257765,42.7708],[20.257055,42.770483],[20.256745,42.770224],[20.256234,42.769974],[20.25577,42.769623],[20.255329,42.769374],[20.254966,42.769249],[20.254407,42.769456],[20.253945,42.769864],[20.253387,42.769909],[20.252897,42.76957],[20.252984,42.769098],[20.253576,42.768448],[20.253321,42.767786],[20.253324,42.76717],[20.253709,42.766935],[20.254213,42.766594],[20.254212,42.765683],[20.254124,42.765231],[20.25399,42.764716],[20.254241,42.764176],[20.253831,42.763609],[20.253402,42.76307],[20.25275,42.762955],[20.252246,42.762896],[20.251321,42.762865],[20.250686,42.762586],[20.250204,42.762193],[20.249872,42.761632],[20.250057,42.761108],[20.250537,42.759448],[20.250496,42.758929],[20.249743,42.758865],[20.249295,42.758931],[20.248789,42.758868],[20.248233,42.758766],[20.247678,42.758664],[20.247122,42.758562],[20.246566,42.75846],[20.246017,42.75838],[20.245284,42.758476],[20.244786,42.758492],[20.244436,42.7582],[20.244148,42.757868],[20.243646,42.757736],[20.243229,42.757622],[20.242653,42.75749],[20.242157,42.757338],[20.241601,42.757193],[20.241184,42.757084],[20.240792,42.75701],[20.240261,42.757001],[20.239705,42.756991],[20.239149,42.756981],[20.238718,42.756961],[20.238301,42.756938],[20.237884,42.756914],[20.237468,42.75689],[20.236912,42.756858],[20.236372,42.756596],[20.236139,42.756105],[20.236033,42.755717],[20.235835,42.75519],[20.235677,42.754773],[20.235416,42.754298],[20.235187,42.753881],[20.234852,42.753442],[20.234428,42.752886],[20.233865,42.752657],[20.233448,42.752574],[20.233058,42.752525],[20.23253,42.752554],[20.231974,42.752584],[20.231419,42.752614],[20.230863,42.752644],[20.230306,42.752705],[20.229691,42.752837],[20.229125,42.752862],[20.228628,42.752887],[20.22813,42.752924],[20.227694,42.752956],[20.227262,42.753009],[20.226862,42.753014],[20.226342,42.753055],[20.225828,42.753118],[20.225305,42.753142],[20.224753,42.753084],[20.224336,42.75311],[20.22395,42.753094],[20.223455,42.752966],[20.22299,42.752825],[20.222634,42.752698],[20.222275,42.752606],[20.221801,42.752619],[20.221346,42.752402],[20.220971,42.752275],[20.220612,42.752108],[20.2202,42.751952],[20.219788,42.751867],[20.219531,42.75168],[20.218933,42.751387],[20.218352,42.750997],[20.217868,42.750666],[20.217437,42.750423],[20.217106,42.750335],[20.216691,42.750042],[20.216274,42.749738],[20.215817,42.749521],[20.215304,42.749186],[20.214746,42.749106],[20.214192,42.74908],[20.213655,42.748856],[20.213162,42.748652],[20.212866,42.748178],[20.212779,42.747831],[20.212847,42.747346],[20.213134,42.747049],[20.212976,42.746601],[20.212778,42.746233],[20.212363,42.746336],[20.211699,42.746708],[20.21093,42.746846],[20.210289,42.746853],[20.20995,42.747287],[20.209585,42.747575],[20.209171,42.747904],[20.208612,42.748121],[20.207976,42.748372],[20.207176,42.748768],[20.206444,42.748905],[20.206121,42.749276],[20.205708,42.749411],[20.205105,42.749432],[20.204566,42.74952],[20.204166,42.749633],[20.203752,42.749676],[20.203469,42.749846],[20.203002,42.749897],[20.202582,42.750085],[20.201941,42.750322],[20.201399,42.750399],[20.201031,42.750214],[20.200473,42.750175],[20.200019,42.750162],[20.199488,42.75009],[20.198974,42.750013],[20.198526,42.750003],[20.19814,42.750024],[20.197759,42.750077],[20.197285,42.750055],[20.196866,42.750155],[20.196336,42.750309],[20.195785,42.750348],[20.195599,42.750065],[20.195251,42.749805],[20.194835,42.749494],[20.194279,42.749079],[20.193841,42.748761],[20.193382,42.748281],[20.192872,42.747749],[20.192522,42.74737],[20.192091,42.746852],[20.191668,42.746305],[20.191367,42.7457],[20.191077,42.745385],[20.190731,42.745764],[20.19038,42.746087],[20.189859,42.746321],[20.189385,42.746725],[20.189042,42.747086],[20.188697,42.747446],[20.188202,42.747959],[20.187798,42.748375],[20.188084,42.749371],[20.187719,42.749628],[20.187259,42.750024],[20.186783,42.750236],[20.186334,42.750286],[20.185726,42.750206],[20.185104,42.750675],[20.184695,42.751617],[20.184281,42.752274],[20.183784,42.752873],[20.183278,42.753384],[20.182858,42.753781],[20.182304,42.753428],[20.181758,42.753282],[20.181375,42.753436],[20.180951,42.753609],[20.180615,42.753884],[20.180214,42.754067],[20.179881,42.754323],[20.179558,42.754546],[20.179216,42.754742],[20.178611,42.754793],[20.178207,42.7549],[20.177802,42.754979],[20.177162,42.75494],[20.176632,42.754934],[20.17629,42.754967],[20.175914,42.755001],[20.175502,42.755061],[20.175127,42.755228],[20.174707,42.755337],[20.174219,42.755416],[20.173698,42.755553],[20.173359,42.755845],[20.173152,42.756141],[20.173207,42.756516],[20.173435,42.757072],[20.173175,42.757694],[20.172687,42.758133],[20.172092,42.758652],[20.171487,42.758943],[20.171016,42.75914],[20.170495,42.759349],[20.170055,42.759677],[20.169409,42.760222],[20.168992,42.760572],[20.168605,42.760906],[20.168217,42.761258],[20.167801,42.761637],[20.167134,42.761953],[20.166578,42.762153],[20.166022,42.762353],[20.165476,42.762564],[20.164929,42.76282],[20.164512,42.763016],[20.164095,42.763211],[20.16354,42.763471],[20.163123,42.763667],[20.162707,42.763862],[20.162151,42.764122],[20.161596,42.764383],[20.16104,42.764643],[20.160484,42.764903],[20.159929,42.765164],[20.159373,42.765424],[20.158894,42.765743],[20.158727,42.766481],[20.158316,42.767029],[20.157864,42.767456],[20.157458,42.767687],[20.15708,42.767913],[20.156673,42.768144],[20.156284,42.768326],[20.155947,42.768551],[20.155598,42.768841],[20.155026,42.7691],[20.154631,42.768539],[20.153039,42.767829],[20.152253,42.767464],[20.151207,42.766917],[20.150721,42.76659],[20.150192,42.766163],[20.149474,42.765427],[20.148856,42.764598],[20.147722,42.763658],[20.148059,42.759747],[20.147918,42.759192],[20.147812,42.758775],[20.147889,42.75821],[20.148012,42.757766],[20.148146,42.757361],[20.148222,42.756821],[20.148129,42.756246],[20.147917,42.755707],[20.147313,42.755566],[20.146877,42.754724],[20.146402,42.75468],[20.145863,42.754808],[20.145321,42.754956],[20.144958,42.755074],[20.144517,42.755094],[20.143955,42.755181],[20.143402,42.755258],[20.142891,42.755441],[20.142555,42.755725],[20.142003,42.755769],[20.141633,42.755972],[20.141103,42.756248],[20.140658,42.756316],[20.140189,42.75643],[20.139724,42.756777],[20.139328,42.75709],[20.138929,42.757327],[20.138573,42.75753],[20.138079,42.757767],[20.137523,42.758033],[20.136968,42.758299],[20.136412,42.758566],[20.135856,42.758832],[20.135301,42.759098],[20.134745,42.759364],[20.134231,42.759589],[20.133717,42.759724],[20.133162,42.759869],[20.132587,42.760029],[20.132038,42.760247],[20.13148,42.760388],[20.130856,42.760574],[20.130375,42.760745],[20.130018,42.760873],[20.12953,42.761052],[20.129056,42.761237],[20.128504,42.761267],[20.127981,42.761152],[20.127623,42.761295],[20.127263,42.761604],[20.126917,42.761961],[20.126517,42.762408],[20.125923,42.762621],[20.125265,42.762656],[20.12472,42.762638],[20.124315,42.762635],[20.123791,42.762677],[20.123221,42.762809],[20.122687,42.762836],[20.122252,42.762791],[20.121711,42.762767],[20.121055,42.762731],[20.120583,42.762485],[20.120005,42.762242],[20.119583,42.762287],[20.119214,42.762772],[20.118771,42.763119],[20.118198,42.763293],[20.117725,42.763471],[20.117341,42.763589],[20.116838,42.763702],[20.116331,42.763728],[20.11598,42.763686],[20.115379,42.763667],[20.114938,42.763386],[20.114347,42.762958],[20.11365,42.762613],[20.113171,42.76245],[20.112717,42.762442],[20.112117,42.762454],[20.111442,42.762521],[20.111011,42.76293],[20.110962,42.763367],[20.110768,42.763913],[20.110396,42.764125],[20.10998,42.76421],[20.109274,42.764291],[20.109016,42.764631],[20.108574,42.764981],[20.107907,42.765483],[20.107499,42.765775],[20.106928,42.766079],[20.106463,42.766264],[20.10603,42.766422],[20.105612,42.766864],[20.105258,42.767312],[20.104929,42.767888],[20.10554,42.768869],[20.105218,42.769378],[20.104787,42.7698],[20.104376,42.769819],[20.103992,42.769976],[20.103758,42.770207],[20.103904,42.770601],[20.104042,42.770974],[20.104229,42.771484],[20.104432,42.77204],[20.104635,42.772596],[20.104788,42.773012],[20.104312,42.773278],[20.103756,42.773588],[20.103207,42.773894],[20.102659,42.774202],[20.102242,42.774436],[20.101825,42.774671],[20.10127,42.774983],[20.100853,42.775217],[20.100436,42.775451],[20.099939,42.77573],[20.09958,42.77593],[20.099164,42.776163],[20.098608,42.776473],[20.098078,42.776715],[20.097686,42.776748],[20.09727,42.776783],[20.096682,42.776802],[20.096094,42.776748],[20.095677,42.77671],[20.095261,42.776672],[20.094649,42.77666],[20.094097,42.776711],[20.093601,42.776635],[20.093045,42.77655],[20.092628,42.776485],[20.092212,42.776422],[20.091702,42.776279],[20.091346,42.776186],[20.090852,42.776163],[20.090435,42.776144],[20.090018,42.776125],[20.089463,42.7761],[20.088903,42.775783],[20.088327,42.775367],[20.087751,42.774975],[20.087244,42.774697],[20.086675,42.77474],[20.086149,42.774812],[20.085662,42.774602],[20.085084,42.774585],[20.084532,42.774682],[20.084076,42.774769],[20.083602,42.774811],[20.082829,42.774891],[20.082244,42.774978],[20.081745,42.775058],[20.081371,42.775016],[20.080953,42.775086],[20.08046,42.775193],[20.079908,42.775105],[20.0795,42.775045],[20.079084,42.775005],[20.078667,42.774963],[20.078121,42.774957],[20.077584,42.774963],[20.077223,42.774967],[20.076807,42.774971],[20.076251,42.774976],[20.07578,42.774992],[20.075364,42.775012],[20.074947,42.775031],[20.074455,42.775019],[20.074038,42.775008],[20.073647,42.775],[20.073116,42.774996],[20.072574,42.774965],[20.07217,42.774875],[20.071834,42.774806],[20.071445,42.774857],[20.071029,42.774911],[20.070612,42.774965],[20.070093,42.774916],[20.069646,42.774939],[20.069313,42.774996],[20.068792,42.775233],[20.068237,42.775487],[20.067742,42.775691],[20.067385,42.775756],[20.067045,42.775899],[20.066795,42.776267],[20.066457,42.776528],[20.065939,42.776909],[20.065528,42.777242],[20.065179,42.777457],[20.064722,42.777712],[20.064194,42.7779],[20.063687,42.778039],[20.063321,42.778148],[20.062945,42.778273],[20.062569,42.778434],[20.062162,42.778607],[20.061755,42.778778],[20.061382,42.778927],[20.060896,42.779045],[20.060378,42.779073],[20.059944,42.778969],[20.059592,42.778742],[20.059344,42.778528],[20.058876,42.778378],[20.058552,42.778222],[20.058066,42.778148],[20.057355,42.778057],[20.05649,42.778254],[20.05592,42.778089],[20.055601,42.777808],[20.055202,42.77774],[20.054763,42.777748],[20.054393,42.777882],[20.054112,42.777662],[20.053647,42.777213],[20.053157,42.776928],[20.052521,42.776741],[20.052114,42.776652],[20.051632,42.776471],[20.05117,42.77616],[20.050642,42.77597],[20.050322,42.775829],[20.050112,42.775601],[20.049774,42.775279],[20.049231,42.774957],[20.048834,42.774553],[20.048562,42.774211],[20.048116,42.773953],[20.047736,42.773767],[20.047343,42.773492],[20.046823,42.773619],[20.046406,42.77372],[20.04599,42.773822],[20.045412,42.774183],[20.044891,42.774503],[20.044509,42.77454],[20.044108,42.774568],[20.043706,42.774571],[20.043303,42.774519],[20.0429,42.774345],[20.042454,42.773986],[20.041834,42.773592],[20.041347,42.773331],[20.04099,42.773247],[20.040593,42.773125],[20.040167,42.772922],[20.039866,42.772767],[20.039429,42.772518],[20.038874,42.7722],[20.03835,42.771643],[20.03796,42.771134],[20.037678,42.770646],[20.03737,42.770355],[20.036913,42.770092],[20.036428,42.769964],[20.035893,42.769925],[20.035408,42.7697],[20.034859,42.769479],[20.034527,42.7693],[20.034009,42.76916],[20.033442,42.768943],[20.03289,42.768449],[20.032398,42.768007],[20.031622,42.767966],[20.031448,42.76756],[20.031476,42.766984],[20.032037,42.766389],[20.031901,42.765884],[20.03145,42.765893],[20.031028,42.765956],[20.030366,42.766151],[20.029636,42.766148],[20.029239,42.766042],[20.028823,42.765986],[20.028195,42.765692],[20.027568,42.765376],[20.026993,42.765096],[20.026519,42.765072],[20.026094,42.765104],[20.025566,42.765159],[20.024965,42.765153],[20.024222,42.765013],[20.023633,42.764906],[20.022961,42.764606],[20.022412,42.764324],[20.023732,42.763125],[20.023927,42.762843],[20.024139,42.7625],[20.024288,42.762154],[20.023933,42.761778],[20.023677,42.761309],[20.023461,42.76096],[20.023242,42.760609],[20.023017,42.760262],[20.022847,42.759795],[20.022722,42.759341],[20.022602,42.758981],[20.0224,42.758621],[20.022444,42.758131],[20.022094,42.757641],[20.022073,42.757217],[20.022115,42.756801],[20.022424,42.756131],[20.022675,42.755612],[20.022774,42.755167],[20.022871,42.754775],[20.023052,42.754275],[20.023318,42.753687],[20.023592,42.753023],[20.023488,42.752551],[20.023344,42.752182],[20.023181,42.751721],[20.022647,42.751297],[20.022123,42.750876],[20.021598,42.750436],[20.021138,42.750013],[20.020851,42.749523],[20.020607,42.749106],[20.020363,42.74869],[20.020125,42.748178],[20.020158,42.747666],[20.020189,42.746979],[20.019923,42.746425],[20.019745,42.745914],[20.019836,42.745542],[20.019849,42.745172],[20.019489,42.744732],[20.018968,42.744548],[20.018553,42.744502],[20.018118,42.744464],[20.017701,42.744426],[20.017353,42.744398],[20.016909,42.744398],[20.01649,42.744519],[20.016146,42.743982],[20.015879,42.743565],[20.015545,42.743221],[20.015351,42.742815],[20.015178,42.742435],[20.015001,42.742055],[20.014804,42.741736],[20.014529,42.741239],[20.014338,42.740699],[20.014605,42.740243],[20.014737,42.739795],[20.014848,42.739431],[20.014955,42.739023],[20.015052,42.738476],[20.015135,42.737952],[20.015166,42.737566],[20.015239,42.737187],[20.015427,42.736809],[20.015627,42.736415],[20.015908,42.735883],[20.016201,42.735327],[20.016173,42.734776],[20.016075,42.734303],[20.016052,42.733919],[20.015771,42.733339],[20.015906,42.732949],[20.015895,42.732522],[20.015747,42.732073],[20.015615,42.731665],[20.015483,42.731158],[20.015325,42.730798],[20.01514,42.73041],[20.014842,42.729883],[20.014589,42.729388],[20.014624,42.729075],[20.014734,42.728708],[20.01499,42.728261],[20.015308,42.727904],[20.015648,42.727645],[20.01602,42.72742],[20.016192,42.727132],[20.016396,42.72682],[20.016729,42.726511],[20.017024,42.726188],[20.01742,42.725847],[20.017856,42.72554],[20.018092,42.725236],[20.018345,42.724767],[20.018637,42.724408],[20.01906,42.724588],[20.019544,42.724416],[20.019939,42.724206],[20.020422,42.724061],[20.02088,42.723809],[20.021439,42.723345],[20.021878,42.723127],[20.022214,42.722916],[20.022632,42.72272],[20.023018,42.722592],[20.023463,42.722468],[20.023975,42.722398],[20.024466,42.722386],[20.024991,42.722453],[20.025511,42.722536],[20.025891,42.722534],[20.026366,42.722327],[20.026771,42.72205],[20.027134,42.721761],[20.027636,42.721384],[20.028131,42.721138],[20.02868,42.72093],[20.029173,42.720725],[20.029749,42.720569],[20.030247,42.72049],[20.030699,42.720434],[20.031064,42.720401],[20.031599,42.720464],[20.032072,42.7205],[20.032186,42.720127],[20.032084,42.719784],[20.031762,42.719497],[20.031342,42.719145],[20.030972,42.718842],[20.030592,42.718594],[20.030059,42.718348],[20.029525,42.718163],[20.02897,42.71797],[20.028414,42.717776],[20.027997,42.717631],[20.027722,42.717445],[20.027734,42.71681],[20.02763,42.716246],[20.027209,42.715757],[20.026799,42.715554],[20.026372,42.715387],[20.025973,42.715309],[20.02549,42.715111],[20.025031,42.714979],[20.024556,42.714809],[20.024202,42.71467],[20.02383,42.714391],[20.02354,42.714021],[20.02294,42.7136],[20.022603,42.713273],[20.022106,42.713198],[20.02172,42.713135],[20.021315,42.713053],[20.020899,42.712961],[20.02045,42.713088],[20.019894,42.713232],[20.019339,42.713376],[20.018783,42.713519],[20.018155,42.713589],[20.017472,42.713426],[20.017028,42.713157],[20.016732,42.712798],[20.016474,42.712397],[20.016391,42.711996],[20.016305,42.711579],[20.016191,42.711024],[20.016077,42.710468],[20.016008,42.709849],[20.016328,42.709748],[20.016639,42.709714],[20.017075,42.70977],[20.01753,42.709933],[20.017991,42.709872],[20.018543,42.709951],[20.019045,42.709834],[20.019414,42.70968],[20.019972,42.709626],[20.020515,42.709616],[20.021053,42.709613],[20.021495,42.709567],[20.022066,42.709626],[20.022522,42.709625],[20.023062,42.709609],[20.023613,42.709654],[20.024107,42.709757],[20.02466,42.709929],[20.025129,42.709938],[20.025642,42.709891],[20.026195,42.709973],[20.026722,42.709869],[20.027161,42.709902],[20.027801,42.709992],[20.028306,42.71],[20.028513,42.710286],[20.02917,42.710449],[20.029767,42.710644],[20.030184,42.71081],[20.030621,42.71091],[20.031095,42.711091],[20.03144,42.711207],[20.031994,42.711457],[20.032526,42.711446],[20.032916,42.71143],[20.033321,42.711438],[20.033708,42.711428],[20.033499,42.710931],[20.033212,42.710313],[20.032939,42.709718],[20.032684,42.709163],[20.032493,42.708746],[20.032303,42.708329],[20.031995,42.707657],[20.031803,42.70724],[20.031614,42.706826],[20.031485,42.706397],[20.031544,42.705872],[20.031647,42.705347],[20.031676,42.704931],[20.031714,42.704375],[20.031752,42.70382],[20.031791,42.703264],[20.031819,42.702847],[20.031848,42.702431],[20.031876,42.702014],[20.032039,42.701462],[20.032204,42.700906],[20.032327,42.700489],[20.03245,42.700073],[20.032614,42.699517],[20.032779,42.698962],[20.032943,42.698406],[20.033066,42.697989],[20.033189,42.697573],[20.033623,42.697331],[20.034165,42.697199],[20.03472,42.697064],[20.035276,42.696929],[20.035755,42.696789],[20.036077,42.69674],[20.036473,42.696728],[20.037006,42.696727],[20.037483,42.696706],[20.037882,42.696663],[20.038314,42.696651],[20.03879,42.696628],[20.039341,42.696556],[20.039981,42.696519],[20.040717,42.696239],[20.041436,42.696245],[20.041801,42.6962],[20.042186,42.696153],[20.042591,42.696174],[20.042956,42.696205],[20.043476,42.696124],[20.04393,42.69601],[20.044413,42.695812],[20.044928,42.69555],[20.045247,42.695223],[20.045783,42.694932],[20.04627,42.694429],[20.04635,42.693945],[20.046496,42.693509],[20.046756,42.693092],[20.047166,42.69285],[20.047655,42.692742],[20.048283,42.692422],[20.048711,42.692147],[20.048963,42.691925],[20.049058,42.691612],[20.049055,42.691261],[20.049265,42.690955],[20.049394,42.690586],[20.049754,42.690414],[20.050069,42.690117],[20.050609,42.689819],[20.051133,42.689694],[20.051613,42.689299],[20.052089,42.688907],[20.052646,42.688568],[20.052924,42.688065],[20.052924,42.687618],[20.052844,42.687196],[20.053066,42.686698],[20.053199,42.686203],[20.053399,42.685895],[20.053579,42.685496],[20.053961,42.685194],[20.054138,42.684929],[20.054441,42.684881],[20.054783,42.684936],[20.055388,42.68489],[20.055912,42.684915],[20.056291,42.684935],[20.05685,42.684886],[20.057404,42.684866],[20.057847,42.684789],[20.058441,42.684481],[20.059035,42.684318],[20.059651,42.684335],[20.060152,42.684462],[20.060534,42.684593],[20.060946,42.684685],[20.061467,42.684793],[20.062036,42.68477],[20.062764,42.684877],[20.063526,42.684891],[20.063966,42.684447],[20.064522,42.68391],[20.065077,42.683374],[20.065633,42.682837],[20.066049,42.682434],[20.066466,42.682032],[20.067021,42.681495],[20.067577,42.680958],[20.068133,42.680422],[20.06881,42.680279],[20.069366,42.68027],[20.069921,42.68026],[20.070338,42.680253],[20.070755,42.680246],[20.07131,42.680237],[20.071866,42.680228],[20.072421,42.680219],[20.072977,42.680209],[20.073532,42.6802],[20.074088,42.680191],[20.074504,42.680184],[20.074921,42.680177],[20.075477,42.680168],[20.076032,42.680159],[20.076449,42.680151],[20.076866,42.680145],[20.077421,42.680136],[20.077977,42.680126],[20.078532,42.680117],[20.079088,42.680108],[20.079643,42.680099],[20.08006,42.680091],[20.080477,42.680085],[20.081032,42.680076],[20.081449,42.680068],[20.081866,42.680062],[20.082421,42.680053],[20.082838,42.680045],[20.083255,42.680039],[20.083601,42.67958],[20.083854,42.679024],[20.084044,42.678607],[20.084234,42.678191],[20.084486,42.677635],[20.084739,42.67708],[20.084929,42.676663],[20.085119,42.676246],[20.085372,42.675691],[20.085561,42.675274],[20.085727,42.674912],[20.085957,42.674411],[20.086148,42.673994],[20.08634,42.673578],[20.086595,42.673022],[20.08685,42.672467],[20.087106,42.671911],[20.087297,42.671494],[20.087488,42.671078],[20.087744,42.670522],[20.087999,42.669967],[20.08819,42.66955],[20.088382,42.669133],[20.088644,42.668688],[20.089131,42.668491],[20.089687,42.668265],[20.090103,42.668096],[20.09052,42.667927],[20.091076,42.667702],[20.091492,42.667532],[20.091909,42.667364],[20.092464,42.667138],[20.09302,42.666913],[20.093436,42.666744],[20.093853,42.666575],[20.094409,42.66635],[20.095034,42.665989],[20.09559,42.665641],[20.096145,42.665293],[20.096701,42.664945],[20.097256,42.664598],[20.097812,42.66425],[20.098367,42.663902],[20.098784,42.663641],[20.099201,42.663381],[20.099617,42.66312],[20.100139,42.662793],[20.100555,42.662533],[20.100972,42.662272],[20.101528,42.661924],[20.102083,42.661576],[20.1025,42.661315],[20.102917,42.661054],[20.103333,42.660794],[20.10375,42.660533],[20.104306,42.660185],[20.104722,42.659924],[20.105139,42.659663],[20.105555,42.659402],[20.105972,42.659141],[20.106528,42.658794],[20.107083,42.658446],[20.1075,42.658185],[20.107917,42.657924],[20.108472,42.657576],[20.108889,42.657315],[20.109306,42.657055],[20.109861,42.656707],[20.110417,42.656359],[20.110833,42.656098],[20.11125,42.655837],[20.111825,42.6555],[20.112476,42.655234],[20.112819,42.655099],[20.11302,42.654812],[20.112641,42.654451],[20.112116,42.654223],[20.111757,42.653833],[20.111277,42.653217],[20.110637,42.652806],[20.110419,42.652121],[20.110233,42.651497],[20.110053,42.651129],[20.110452,42.650627],[20.110631,42.650098],[20.110333,42.649725],[20.109997,42.649448],[20.109445,42.649218],[20.109076,42.648969],[20.108862,42.648649],[20.108912,42.648177],[20.10877,42.647819],[20.108178,42.647765],[20.107454,42.647487],[20.106637,42.64718],[20.106267,42.647108],[20.105702,42.646934],[20.105208,42.646741],[20.104847,42.64658],[20.104406,42.646331],[20.103917,42.646063],[20.103453,42.645883],[20.103066,42.645688],[20.102763,42.645444],[20.10224,42.645064],[20.101689,42.644859],[20.101341,42.64476],[20.100915,42.644636],[20.100481,42.644465],[20.099916,42.644291],[20.099459,42.644021],[20.099012,42.643777],[20.09863,42.643628],[20.098226,42.643427],[20.097709,42.643125],[20.097155,42.642732],[20.096728,42.642362],[20.096705,42.642023],[20.096494,42.641718],[20.09591,42.64122],[20.095479,42.640912],[20.09499,42.640652],[20.094524,42.6402],[20.093881,42.63966],[20.093666,42.639112],[20.093618,42.6387],[20.093555,42.638274],[20.09322,42.637829],[20.092962,42.637495],[20.09277,42.637155],[20.092516,42.636702],[20.092306,42.636178],[20.092186,42.635603],[20.092224,42.635118],[20.092277,42.634686],[20.092158,42.634242],[20.091723,42.633793],[20.091172,42.633324],[20.090659,42.633],[20.090471,42.632601],[20.090125,42.632128],[20.089907,42.631523],[20.089796,42.631092],[20.089481,42.630793],[20.089144,42.630554],[20.088775,42.630251],[20.088451,42.62975],[20.088207,42.629176],[20.087911,42.628928],[20.087432,42.628716],[20.086999,42.628329],[20.08668,42.627927],[20.086249,42.627672],[20.085751,42.627527],[20.08525,42.627406],[20.084862,42.627342],[20.084324,42.627368],[20.083908,42.627338],[20.083496,42.627221],[20.083006,42.627007],[20.082628,42.626773],[20.082185,42.626512],[20.081804,42.626255],[20.081439,42.625904],[20.080818,42.625477],[20.080528,42.625001],[20.079936,42.624487],[20.079345,42.624229],[20.078905,42.624055],[20.078567,42.623865],[20.078256,42.623653],[20.077916,42.623152],[20.077428,42.622538],[20.077149,42.621962],[20.076811,42.621374],[20.076193,42.620929],[20.075783,42.620642],[20.075894,42.620117],[20.075886,42.619592],[20.07585,42.61916],[20.075861,42.618827],[20.075909,42.618331],[20.075925,42.617756],[20.075922,42.617366],[20.075944,42.616934],[20.075934,42.616469],[20.075716,42.615996],[20.075691,42.615502],[20.075899,42.615062],[20.076174,42.614502],[20.076047,42.614042],[20.075824,42.613684],[20.075661,42.613256],[20.075389,42.612908],[20.075199,42.612432],[20.075229,42.61203],[20.075143,42.611684],[20.075222,42.611282],[20.074943,42.610888],[20.074717,42.610597],[20.074442,42.610279],[20.074013,42.609604],[20.073645,42.609103],[20.073244,42.608695],[20.072877,42.608209],[20.072763,42.607771],[20.072761,42.607273],[20.072848,42.606761],[20.072979,42.606394],[20.073333,42.605817],[20.073673,42.60546],[20.07416,42.605154],[20.074521,42.604562],[20.074679,42.603946],[20.074694,42.60347],[20.074773,42.602845],[20.074804,42.602352],[20.074918,42.601947],[20.075289,42.601266],[20.075687,42.600734],[20.076031,42.600334],[20.076461,42.599755],[20.076782,42.599444],[20.077034,42.599155],[20.077263,42.598859],[20.077476,42.598595],[20.077782,42.59826],[20.078142,42.598022],[20.078502,42.597886],[20.078976,42.597653],[20.079259,42.597196],[20.079534,42.596697],[20.07971,42.596225],[20.07981,42.59582],[20.07981,42.59531],[20.080498,42.594896],[20.080773,42.594532],[20.080825,42.594183],[20.08104,42.593812],[20.081049,42.593114],[20.081089,42.5922],[20.08127,42.591732],[20.081478,42.591225],[20.082056,42.591066],[20.082486,42.590873],[20.083003,42.590677],[20.083506,42.590391],[20.083919,42.59002],[20.084281,42.589603],[20.084725,42.589094],[20.084889,42.588625],[20.085463,42.588424],[20.085889,42.587717],[20.086232,42.587245],[20.086336,42.586759],[20.086205,42.586321],[20.086062,42.585839],[20.085629,42.585316],[20.08569,42.58482],[20.085811,42.584402],[20.085851,42.583946],[20.085829,42.583548],[20.085781,42.583101],[20.085749,42.582573],[20.086257,42.582104],[20.086784,42.581754],[20.087076,42.581455],[20.087247,42.581053],[20.08732,42.580586],[20.087383,42.580169],[20.087445,42.579752],[20.087507,42.579336],[20.087575,42.578757],[20.088073,42.578381],[20.088335,42.577911],[20.088382,42.577238],[20.088366,42.576807],[20.088333,42.576375],[20.088151,42.575832],[20.088097,42.575356],[20.088133,42.574782],[20.088173,42.574095],[20.087676,42.57347],[20.087005,42.572923],[20.086601,42.572549],[20.086016,42.572259],[20.085597,42.571951],[20.084996,42.571537],[20.084695,42.571329],[20.084302,42.571042],[20.08398,42.570595],[20.083845,42.570143],[20.083935,42.569734],[20.084074,42.569323],[20.084131,42.568949],[20.084003,42.568449],[20.084445,42.568267],[20.084215,42.567921],[20.083804,42.56737],[20.083752,42.566878],[20.083379,42.566538],[20.082806,42.566166],[20.082754,42.565476],[20.082443,42.564887],[20.082008,42.564309],[20.081552,42.563799],[20.081335,42.563185],[20.080913,42.56264],[20.080685,42.562259],[20.080528,42.561893],[20.080378,42.561543],[20.080314,42.561168],[20.079891,42.560848],[20.079581,42.56059],[20.079226,42.560073],[20.079102,42.559578],[20.078979,42.559276],[20.0789,42.558898],[20.078883,42.558456],[20.078777,42.558109],[20.078855,42.55756],[20.078919,42.556789],[20.078889,42.556229],[20.078895,42.555799],[20.077818,42.555968],[20.076968,42.556265],[20.076117,42.556314],[20.075136,42.556215],[20.074547,42.555968],[20.073892,42.555819],[20.073107,42.555671],[20.072387,42.55577],[20.070817,42.555968],[20.06977,42.556314],[20.069181,42.55671],[20.068003,42.557006],[20.06676,42.556759],[20.065582,42.556858],[20.064797,42.557006],[20.063881,42.557451],[20.063423,42.557748],[20.062507,42.558243],[20.061722,42.558589],[20.060086,42.558836],[20.059039,42.558984],[20.057861,42.559083],[20.055833,42.559257],[20.055048,42.558737],[20.054197,42.557649],[20.053674,42.556561],[20.053085,42.555523],[20.050664,42.55211],[20.049944,42.551468],[20.048701,42.550627],[20.048308,42.550231],[20.046542,42.549737],[20.045102,42.549489],[20.043793,42.549292],[20.042092,42.548945],[20.040783,42.548649],[20.039606,42.548055],[20.037839,42.54761],[20.034764,42.546819],[20.03195,42.546275],[20.030249,42.545879],[20.029071,42.545286],[20.027632,42.544247],[20.026585,42.543852],[20.024556,42.543308],[20.022331,42.543505],[20.019583,42.543753],[20.018209,42.543901],[20.01605,42.543407],[20.01533,42.542665],[20.014741,42.542022],[20.01461,42.540983],[20.014283,42.539945],[20.013956,42.538214],[20.013629,42.537175],[20.014022,42.536186],[20.014283,42.535642],[20.014741,42.534357],[20.014872,42.532922],[20.01533,42.531834],[20.015526,42.530845],[20.015461,42.530301],[20.014545,42.529016],[20.013891,42.527878],[20.013302,42.527037],[20.012386,42.526345],[20.012059,42.525949],[20.011993,42.524664],[20.011993,42.523872],[20.011731,42.522784],[20.011143,42.521696],[20.009965,42.52051],[20.008787,42.51957],[20.008263,42.518334],[20.008329,42.516998],[20.00846,42.515762],[20.00846,42.514723],[20.008133,42.51413],[20.007413,42.513141],[20.005973,42.5123],[20.004861,42.511459],[20.003487,42.510619],[20.002833,42.509828],[20.001982,42.509531],[20.000281,42.510174],[19.997925,42.510915],[19.996747,42.511361],[19.994523,42.512003],[19.993083,42.512449],[19.991905,42.512795],[19.990793,42.512894],[19.989615,42.512844],[19.987456,42.512745],[19.985689,42.512745],[19.984381,42.512844],[19.982352,42.512894],[19.981371,42.513339],[19.980455,42.513635],[19.978688,42.513487],[19.977314,42.513091],[19.976463,42.512844],[19.975809,42.512646],[19.974697,42.512498],[19.972472,42.512646],[19.971098,42.512399],[19.970247,42.512003],[19.96848,42.511163],[19.968088,42.510817],[19.966714,42.51047],[19.96462,42.51052],[19.962526,42.510965],[19.960956,42.511064],[19.959189,42.511459],[19.957226,42.511806],[19.954674,42.511905],[19.953104,42.511905],[19.952319,42.512102],[19.951206,42.51319],[19.950225,42.513883],[19.949309,42.514278],[19.947607,42.514872],[19.946561,42.515366],[19.946103,42.516504],[19.943812,42.517888],[19.943093,42.518432],[19.942111,42.51863],[19.940868,42.518432],[19.938709,42.517691],[19.937596,42.516949],[19.936157,42.516751],[19.934128,42.516553],[19.932035,42.516084],[19.929286,42.514773],[19.928174,42.514278],[19.923725,42.512646],[19.922154,42.511657],[19.920976,42.510668],[19.919799,42.509877],[19.917705,42.50874],[19.916462,42.508097],[19.914695,42.50775],[19.91319,42.507404],[19.911227,42.507206],[19.909918,42.50686],[19.907628,42.507058],[19.906647,42.507652],[19.905731,42.507899],[19.905273,42.506959],[19.9056,42.505624],[19.905403,42.504388],[19.904749,42.5033],[19.903899,42.502261],[19.903899,42.500679],[19.903833,42.499096],[19.904029,42.497959],[19.90416,42.496722],[19.904815,42.494596],[19.905011,42.493162],[19.904618,42.492024],[19.903833,42.490837],[19.902721,42.489997],[19.901543,42.489403],[19.900496,42.488958],[19.89958,42.488612],[19.899384,42.48787],[19.89886,42.48693],[19.898206,42.486238],[19.897224,42.485595],[19.896636,42.485298],[19.896047,42.485249],[19.895,42.485941],[19.893887,42.486881],[19.892382,42.48787],[19.89055,42.488711],[19.889111,42.489205],[19.887802,42.490095],[19.886886,42.49148],[19.886559,42.492568],[19.885708,42.493706],[19.884661,42.494546],[19.883091,42.49509],[19.881586,42.495535],[19.880801,42.495733],[19.878838,42.495931],[19.877725,42.495832],[19.875828,42.495535],[19.875435,42.494843],[19.875239,42.494002],[19.875108,42.492964],[19.875435,42.491727],[19.875959,42.490837],[19.874846,42.490392],[19.873996,42.490293],[19.873014,42.4897],[19.872753,42.489057],[19.872753,42.488414],[19.872883,42.487079],[19.872556,42.485991],[19.87236,42.485397],[19.871117,42.484754],[19.870135,42.48426],[19.869154,42.483469],[19.867911,42.48243],[19.867256,42.482133],[19.865751,42.482035],[19.864116,42.481936],[19.862545,42.482282],[19.861564,42.482776],[19.859993,42.483419],[19.859012,42.483963],[19.85803,42.484458],[19.85718,42.484408],[19.854955,42.483963],[19.853515,42.483815],[19.852992,42.48332],[19.852599,42.482282],[19.852207,42.481688],[19.851683,42.481194],[19.851094,42.48065],[19.850702,42.480155],[19.850375,42.47976],[19.849459,42.479216],[19.848608,42.479117],[19.846318,42.479315],[19.84357,42.479562],[19.841083,42.480056],[19.840494,42.480056],[19.839644,42.479859],[19.838466,42.479463],[19.837615,42.479265],[19.836896,42.479067],[19.836438,42.478721],[19.836568,42.47788],[19.837746,42.475952],[19.838597,42.474468],[19.838204,42.473726],[19.837484,42.472638],[19.835914,42.471105],[19.834671,42.469622],[19.832773,42.467742],[19.832184,42.46705],[19.831268,42.466407],[19.829829,42.466654],[19.824136,42.468484],[19.820014,42.469622],[19.816742,42.470611],[19.815695,42.471006],[19.814845,42.471995],[19.814256,42.472985],[19.813929,42.473331],[19.812358,42.473924],[19.81033,42.474567],[19.808367,42.475309],[19.806339,42.475952],[19.804114,42.477139],[19.801955,42.478474],[19.799206,42.479512],[19.797114,42.480314],[19.793401,42.481909],[19.791654,42.482569],[19.790053,42.484769],[19.787723,42.487465],[19.785467,42.490271],[19.783137,42.493241],[19.782045,42.494727],[19.780589,42.496762],[19.778041,42.497477],[19.772654,42.499073],[19.769014,42.500228],[19.766102,42.501218],[19.765593,42.501493],[19.763991,42.502648],[19.763409,42.503914],[19.762899,42.505399],[19.761735,42.510185],[19.761225,42.511835],[19.760497,42.513101],[19.760206,42.515246],[19.759842,42.516291],[19.759915,42.517391],[19.759842,42.520142],[19.759478,42.520527],[19.758386,42.522123],[19.758095,42.523443],[19.756857,42.524488],[19.755037,42.525313],[19.754164,42.527184],[19.753144,42.528284],[19.752635,42.528724],[19.752635,42.529274],[19.752271,42.530429],[19.752489,42.531254],[19.753436,42.53186],[19.753436,42.532575],[19.752489,42.533565],[19.752198,42.53417],[19.751288,42.53472],[19.750888,42.535325],[19.75016,42.535435],[19.749577,42.535105],[19.748631,42.535875],[19.747903,42.536206],[19.74783,42.537306],[19.747612,42.538076],[19.747685,42.538846],[19.747102,42.539451],[19.745937,42.540166],[19.745792,42.541872],[19.745355,42.542422],[19.7447,42.542807],[19.744336,42.543687],[19.743681,42.544457],[19.743608,42.545117],[19.743826,42.545778],[19.743826,42.546328],[19.74419,42.547318],[19.745501,42.548418],[19.746738,42.548803],[19.747903,42.549023],[19.748631,42.549793],[19.749141,42.550399],[19.749723,42.551114],[19.74965,42.551664],[19.749359,42.552104],[19.749141,42.552819],[19.748922,42.553369],[19.748995,42.553864],[19.749286,42.554745],[19.748777,42.55568],[19.748849,42.556395],[19.749068,42.557495],[19.749796,42.5581],[19.750087,42.558815],[19.750379,42.559476],[19.751106,42.560576],[19.751616,42.561346],[19.752271,42.561676],[19.752926,42.562226],[19.753144,42.563106],[19.753436,42.563601],[19.753909,42.56451],[19.753872,42.565087],[19.754164,42.565637],[19.754091,42.566242],[19.753581,42.567122],[19.752635,42.567452],[19.751834,42.567672],[19.751106,42.568222],[19.750378,42.568552],[19.749577,42.569378],[19.748995,42.570478],[19.748777,42.571358],[19.748485,42.573118],[19.748922,42.574329],[19.749213,42.575539],[19.750087,42.576584],[19.75096,42.577299],[19.752344,42.577794],[19.752635,42.57818],[19.752052,42.579115],[19.751834,42.57972],[19.752271,42.5806],[19.752635,42.581095],[19.753072,42.58126],[19.754164,42.581095],[19.75511,42.58104],[19.755838,42.58093],[19.756275,42.580435],[19.756784,42.580105],[19.757876,42.57994],[19.758968,42.580215],[19.759478,42.580545],[19.759696,42.58181],[19.760715,42.582801],[19.761589,42.583186],[19.762171,42.583241],[19.762972,42.583461],[19.763554,42.583516],[19.764719,42.582911],[19.765593,42.583076],[19.766175,42.583241],[19.767049,42.582801],[19.768359,42.582746],[19.771708,42.582525],[19.772727,42.58258],[19.773819,42.58258],[19.774765,42.582856],[19.775056,42.584011],[19.774329,42.585661],[19.775056,42.585936],[19.775348,42.587256],[19.775202,42.588027],[19.774401,42.589237],[19.774692,42.590447],[19.774692,42.591217],[19.774329,42.592098],[19.774037,42.592538],[19.773673,42.593088],[19.773164,42.593528],[19.772145,42.594848],[19.771417,42.596003],[19.771053,42.596498],[19.770106,42.597434],[19.767922,42.599194],[19.76734,42.599689],[19.766758,42.600239],[19.766248,42.601064],[19.765593,42.60156],[19.76501,42.602],[19.761225,42.605355],[19.759259,42.606841],[19.758968,42.607501],[19.759915,42.610361],[19.758823,42.611022],[19.754382,42.612617],[19.752489,42.613442],[19.751252,42.614102],[19.751761,42.617018],[19.752926,42.620319],[19.752198,42.621364],[19.751252,42.622244],[19.750305,42.623289],[19.749869,42.624169],[19.749505,42.625765],[19.749432,42.62758],[19.749723,42.62901],[19.750596,42.630551],[19.751761,42.631431],[19.753654,42.632366],[19.754892,42.633301],[19.755984,42.634512],[19.756639,42.635062],[19.75693,42.635997],[19.756711,42.636547],[19.755692,42.637372],[19.754528,42.638307],[19.752198,42.639793],[19.749505,42.640948],[19.748631,42.641113],[19.747685,42.640948],[19.745865,42.640838],[19.743608,42.641113],[19.742079,42.641333],[19.740478,42.642158],[19.739022,42.642323],[19.738003,42.642378],[19.737639,42.642653],[19.737711,42.643149],[19.737275,42.643699],[19.737493,42.644909],[19.737639,42.646119],[19.737129,42.647329],[19.736838,42.648595],[19.736765,42.6492],[19.735819,42.64964],[19.735455,42.65074],[19.735163,42.651125],[19.734581,42.65206],[19.734872,42.652996],[19.735018,42.653436],[19.733707,42.655526],[19.732761,42.656901],[19.73196,42.657397],[19.731742,42.657837],[19.731232,42.658882],[19.730286,42.659597],[19.728976,42.660202],[19.728102,42.660532],[19.727083,42.660752],[19.7265,42.660807],[19.7257,42.660642],[19.725263,42.660532],[19.724244,42.661027],[19.723516,42.661082],[19.722861,42.660917],[19.722205,42.660477],[19.721113,42.660092],[19.720094,42.659817],[19.718784,42.659157],[19.717983,42.658552],[19.71711,42.658167],[19.716163,42.658057],[19.713906,42.657452],[19.714052,42.657011],[19.713906,42.656571],[19.713397,42.656186],[19.712159,42.655636],[19.710631,42.655746],[19.709975,42.655691],[19.709247,42.655416],[19.708665,42.655196],[19.707646,42.654921],[19.706554,42.654756],[19.705826,42.654756],[19.705462,42.655526],[19.704952,42.655911],[19.704152,42.656241],[19.70386,42.655471],[19.704006,42.654371],[19.70386,42.653436],[19.70306,42.65228],[19.70255,42.651895],[19.701822,42.651235],[19.701167,42.651235],[19.700148,42.650795],[19.698765,42.650465],[19.698473,42.64931],[19.699565,42.64788],[19.699784,42.646999],[19.699784,42.645679],[19.699457,42.644689],[19.697381,42.644359],[19.696362,42.644194],[19.695634,42.644139],[19.695125,42.643479],[19.694688,42.642598],[19.694033,42.641663],[19.693378,42.640948],[19.693232,42.640563],[19.692941,42.639793],[19.692358,42.639298],[19.690684,42.638968],[19.688282,42.639078],[19.687627,42.639518],[19.68668,42.638638],[19.685989,42.637152],[19.686316,42.636217],[19.685807,42.635612],[19.684787,42.635007],[19.684569,42.634017],[19.683987,42.633136],[19.683841,42.632641],[19.685443,42.631871],[19.685515,42.630936],[19.685661,42.630386],[19.685952,42.629726],[19.686607,42.629616],[19.686971,42.6289],[19.686753,42.62802],[19.685006,42.62824],[19.684278,42.628075],[19.683477,42.627635],[19.682531,42.62736],[19.681803,42.62725],[19.680128,42.62736],[19.679328,42.627855],[19.677217,42.6278],[19.675761,42.6278],[19.674814,42.62835],[19.674159,42.62835],[19.673649,42.62813],[19.672703,42.628515],[19.672048,42.6289],[19.671829,42.629396],[19.671465,42.629616],[19.6695,42.630111],[19.668554,42.629891],[19.667826,42.629946],[19.667025,42.629891],[19.666442,42.629671],[19.665423,42.629781],[19.664914,42.629671],[19.663676,42.629341],[19.66273,42.62879],[19.662147,42.62824],[19.661347,42.62648],[19.660691,42.62505],[19.660182,42.624389],[19.65858,42.622684],[19.655304,42.619163],[19.651082,42.614817],[19.645477,42.608876],[19.641254,42.60464],[19.638925,42.60222],[19.638488,42.601615],[19.637615,42.601009],[19.63463,42.598809],[19.632009,42.596223],[19.628733,42.593913],[19.62735,42.592978],[19.62735,42.592538],[19.627714,42.592208],[19.62786,42.591822],[19.627423,42.590997],[19.625312,42.588962],[19.623419,42.587367],[19.622764,42.586596],[19.620143,42.584231],[19.617741,42.58225],[19.615047,42.57972],[19.6133,42.578235],[19.612281,42.576969],[19.611189,42.575319],[19.610607,42.574604],[19.610534,42.573724],[19.611116,42.572568],[19.612499,42.570038],[19.612354,42.569488],[19.612208,42.569103],[19.611771,42.568442],[19.611553,42.567122],[19.611262,42.566517],[19.610607,42.565472],[19.609588,42.563876],[19.609733,42.562666],[19.609806,42.561841],[19.610316,42.560026],[19.610607,42.559255],[19.610898,42.55788],[19.61148,42.555625],[19.611844,42.554745],[19.612354,42.553809],[19.61381,42.552544],[19.614756,42.551719],[19.615411,42.550894],[19.615339,42.550234],[19.615484,42.549133],[19.616067,42.548253],[19.616722,42.547593],[19.61694,42.546988],[19.616503,42.545723],[19.616212,42.544347],[19.615994,42.543797],[19.616722,42.542807],[19.617304,42.542092],[19.617377,42.541432],[19.616212,42.540276],[19.613737,42.539121],[19.611917,42.538406],[19.610388,42.538131],[19.608932,42.537856],[19.60784,42.537801],[19.60704,42.537251],[19.606676,42.536481],[19.606457,42.535875],[19.605875,42.535325],[19.604492,42.53494],[19.6034,42.534665],[19.6034,42.534225],[19.603982,42.533015],[19.604055,42.5323],[19.603837,42.531585],[19.603181,42.530704],[19.601725,42.529769],[19.600269,42.529054],[19.595465,42.527184],[19.590951,42.525258],[19.584836,42.522728],[19.580177,42.520857],[19.575737,42.519097],[19.570786,42.517116],[19.567729,42.515796],[19.565982,42.515026],[19.564817,42.514641],[19.563288,42.514366],[19.56176,42.514311],[19.562269,42.513376],[19.562487,42.51167],[19.562633,42.509525],[19.562342,42.507379],[19.562051,42.505729],[19.561104,42.503914],[19.561032,42.502373],[19.560522,42.501218],[19.560085,42.500063],[19.560147,42.498936],[19.559994,42.498011],[19.559841,42.497144],[19.559535,42.495757],[19.559382,42.494803],[19.559458,42.494138],[19.559229,42.493618],[19.558693,42.493155],[19.557852,42.492982],[19.557316,42.492288],[19.556628,42.49119],[19.556093,42.490207],[19.555328,42.489802],[19.553721,42.489282],[19.550891,42.488357],[19.549896,42.487952],[19.549131,42.487259],[19.54829,42.486854],[19.548137,42.48616],[19.547601,42.485524],[19.546071,42.484715],[19.545459,42.483443],[19.544388,42.481998],[19.543088,42.480958],[19.541787,42.479108],[19.540869,42.477084],[19.540181,42.475177],[19.539492,42.474541],[19.538498,42.473674],[19.538192,42.472749],[19.538268,42.472286],[19.538192,42.471708],[19.537962,42.470205],[19.53758,42.468586],[19.537656,42.467777],[19.53735,42.466563],[19.537121,42.465869],[19.535973,42.465002],[19.535208,42.464482],[19.53452,42.463904],[19.533908,42.462921],[19.533372,42.461996],[19.533143,42.461245],[19.532684,42.460493],[19.531919,42.459453],[19.531077,42.458643],[19.529241,42.458007],[19.526564,42.457082],[19.525263,42.456215],[19.524192,42.455117],[19.522892,42.453383],[19.521821,42.4524],[19.521132,42.451706],[19.519985,42.450087],[19.519526,42.448411],[19.519602,42.44737],[19.518914,42.44633],[19.518761,42.445405],[19.518837,42.444133],[19.518531,42.443208],[19.518149,42.442514],[19.517613,42.442341],[19.51593,42.441763],[19.5144,42.441416],[19.512335,42.441185],[19.510805,42.440433],[19.51004,42.439971],[19.507668,42.439219],[19.506444,42.438699],[19.50522,42.438352],[19.503537,42.43789],[19.502925,42.437485],[19.502543,42.43656],[19.502237,42.435635],[19.501854,42.434768],[19.501013,42.433959],[19.4991,42.43286],[19.498605,42.431627],[19.498416,42.431199],[19.498152,42.430228],[19.497887,42.4292],[19.497774,42.428543],[19.497963,42.427858],[19.498114,42.42703],[19.498378,42.426002],[19.498454,42.425259],[19.498492,42.424431],[19.498416,42.423346],[19.498265,42.422746],[19.49766,42.422575],[19.496867,42.422603],[19.495922,42.422775],[19.495393,42.42286],[19.494524,42.422918],[19.493919,42.422889],[19.49339,42.422689],[19.492824,42.421889],[19.492106,42.420319],[19.491312,42.419034],[19.49067,42.417578],[19.489574,42.414922],[19.488969,42.413922],[19.48878,42.413066],[19.488554,42.412152],[19.488478,42.411552],[19.488365,42.410867],[19.488214,42.410181],[19.487609,42.409239],[19.486891,42.408325],[19.485342,42.407012],[19.484246,42.406212],[19.483112,42.405327],[19.48179,42.404213],[19.481034,42.403642],[19.480354,42.403042],[19.479938,42.4023],[19.479409,42.401043],[19.47888,42.39993],[19.478049,42.398473],[19.477255,42.396732],[19.476764,42.395332],[19.476084,42.39399],[19.474988,42.393333],[19.474232,42.392819],[19.473854,42.392448],[19.473552,42.391706],[19.473061,42.391063],[19.471852,42.390421],[19.470567,42.389878],[19.470189,42.389592],[19.469509,42.388736],[19.468148,42.38825],[19.466259,42.388022],[19.465352,42.387822],[19.464256,42.387308],[19.46044,42.385709],[19.458399,42.384766],[19.456963,42.384195],[19.455792,42.383738],[19.455263,42.383567],[19.453336,42.383424],[19.4502,42.383596],[19.448537,42.383738],[19.448083,42.383767],[19.447517,42.383567],[19.44506,42.382796],[19.443587,42.382196],[19.44268,42.38174],[19.441206,42.381054],[19.438221,42.379826],[19.436823,42.379141],[19.43584,42.378598],[19.435538,42.378313],[19.43482,42.377627],[19.43414,42.376742],[19.43346,42.376171],[19.432553,42.375114],[19.432175,42.374743],[19.431041,42.374029],[19.430021,42.373401],[19.428888,42.372573],[19.427792,42.371916],[19.426696,42.371231],[19.426167,42.370403],[19.425827,42.369489],[19.426356,42.368404],[19.426242,42.367861],[19.425902,42.36749],[19.42492,42.367062],[19.424164,42.366833],[19.423748,42.366405],[19.423522,42.365777],[19.423333,42.365006],[19.423182,42.364006],[19.423144,42.363264],[19.423257,42.362236],[19.423408,42.361493],[19.42356,42.360808],[19.424618,42.358495],[19.42492,42.357495],[19.424882,42.357067],[19.424769,42.356382],[19.424655,42.355953],[19.423937,42.355296],[19.422615,42.354268],[19.42167,42.353355],[19.420952,42.352755],[19.420385,42.35227],[19.419176,42.35187],[19.417929,42.351242],[19.416191,42.35047],[19.415171,42.350099],[19.41468,42.349871],[19.41468,42.349385],[19.414868,42.348729],[19.41536,42.345987],[19.415738,42.344217],[19.416153,42.342132],[19.416342,42.340162],[19.416493,42.338448],[19.41672,42.336021],[19.416758,42.335364],[19.417211,42.33465],[19.418307,42.333223],[19.419705,42.331424],[19.420725,42.330167],[19.421179,42.329453],[19.421784,42.328711],[19.422048,42.328225],[19.422294,42.326897],[19.421368,42.326169],[19.416229,42.321829],[19.413659,42.319744],[19.412034,42.318288],[19.407991,42.314947],[19.406215,42.313433],[19.404099,42.311634],[19.401605,42.309549],[19.398431,42.307008],[19.395824,42.305066],[19.393519,42.302896],[19.392763,42.302239],[19.391969,42.301754],[19.390949,42.30104],[19.39042,42.300611],[19.38906,42.298898],[19.387926,42.297156],[19.386415,42.2953],[19.385432,42.294272],[19.385054,42.293672],[19.384658,42.292816],[19.384601,42.291159],[19.384828,42.28936],[19.385017,42.287904],[19.385205,42.286476],[19.385243,42.284591],[19.385243,42.283335],[19.38513,42.282821],[19.384601,42.281793],[19.384374,42.281365],[19.382258,42.279537],[19.380369,42.277766],[19.379122,42.276539],[19.376477,42.273826],[19.375154,42.272398],[19.373869,42.271084],[19.371224,42.2684],[19.369977,42.267001],[19.368201,42.26523],[19.366916,42.264059],[19.365783,42.262432],[19.364687,42.26129],[19.363553,42.260062],[19.362646,42.259148],[19.361853,42.258205],[19.360946,42.257177],[19.359926,42.255892],[19.359132,42.254493],[19.357696,42.252637],[19.357243,42.251837],[19.356714,42.250981],[19.35626,42.250124],[19.354149,42.24675],[19.352489,42.244052],[19.350331,42.24079],[19.349999,42.240225],[19.346927,42.23759],[19.341697,42.232822],[19.335886,42.227804],[19.332732,42.225043],[19.327253,42.220213],[19.32003,42.213751],[19.316461,42.210677],[19.313306,42.208042],[19.310401,42.205282],[19.305088,42.200765],[19.29853,42.194993],[19.295873,42.192798],[19.289555,42.187471],[19.314259,42.173343],[19.345018,42.155752],[19.377151,42.137375],[19.4121,42.117387],[19.402214,42.10279],[19.388932,42.082447],[19.386276,42.07862],[19.384948,42.07724],[19.383868,42.076299],[19.383204,42.07517],[19.38254,42.073915],[19.38171,42.073037],[19.380216,42.072033],[19.378971,42.071218],[19.379137,42.070214],[19.379967,42.068834],[19.380548,42.067767],[19.380133,42.06576],[19.379054,42.062184],[19.37814,42.059235],[19.377891,42.057792],[19.378472,42.05591],[19.378722,42.055095],[19.37922,42.052836],[19.380216,42.050891],[19.380465,42.05039],[19.378971,42.049072],[19.378223,42.048068],[19.377476,42.047002],[19.376397,42.045622],[19.375733,42.044304],[19.37482,42.042422],[19.374073,42.04054],[19.372828,42.039097],[19.371831,42.038219],[19.371499,42.037027],[19.371333,42.035835],[19.371167,42.034392],[19.370586,42.033137],[19.371997,42.031506],[19.372163,42.030754],[19.371748,42.029875],[19.371333,42.028746],[19.371748,42.027491],[19.372246,42.025233],[19.372661,42.024606],[19.37399,42.023414],[19.374654,42.022661],[19.37482,42.021469],[19.374073,42.01965],[19.373409,42.018018],[19.373243,42.016575],[19.373243,42.015572],[19.373243,42.014631],[19.37399,42.013],[19.374571,42.011055],[19.37482,42.009988],[19.374737,42.009047],[19.375318,42.006977],[19.375982,42.005848],[19.376978,42.00453],[19.378639,42.00384],[19.380465,42.002962],[19.381295,42.002272],[19.382457,42.000014],[19.382457,41.99901],[19.382125,41.997755],[19.38171,41.996563],[19.380797,41.995246],[19.38005,41.993552],[19.379718,41.99167],[19.379552,41.990039],[19.379718,41.987968],[19.379967,41.987153],[19.380299,41.986024],[19.379884,41.984643],[19.379137,41.983326],[19.378057,41.98182],[19.377476,41.981068],[19.376978,41.980315],[19.37648,41.97906],[19.375899,41.978056],[19.37565,41.976802],[19.375401,41.976049],[19.375235,41.975359],[19.375401,41.974606],[19.376065,41.97379],[19.378057,41.972724],[19.379718,41.972159],[19.381295,41.971595],[19.382872,41.970905],[19.38445,41.969775],[19.386608,41.96827],[19.387687,41.967203],[19.387936,41.96645],[19.387355,41.965258],[19.385944,41.964066],[19.384699,41.963],[19.383453,41.962184],[19.382623,41.961683],[19.38088,41.961243],[19.37399,41.960365],[19.371499,41.959926],[19.370171,41.959675],[19.367598,41.95955],[19.362783,41.9598],[19.360043,41.959989],[19.358881,41.9598],[19.357802,41.95955],[19.356059,41.959236],[19.354066,41.958609],[19.352157,41.957856],[19.35141,41.957166],[19.350497,41.956476],[19.349832,41.955472],[19.349666,41.954782],[19.350165,41.953213],[19.350497,41.95221],[19.350663,41.951206],[19.350331,41.949261],[19.349832,41.947881],[19.349168,41.946187],[19.34867,41.944242],[19.348753,41.942047],[19.349168,41.940855],[19.349916,41.9396],[19.351991,41.937718],[19.354564,41.93571],[19.356723,41.934518],[19.359296,41.933013],[19.362534,41.93157],[19.365771,41.929939],[19.3671,41.928621],[19.368013,41.927618],[19.369092,41.926426],[19.369673,41.925547],[19.370088,41.924167],[19.370088,41.92285],[19.369424,41.92147],[19.368843,41.920528],[19.3671,41.919148],[19.365522,41.918207],[19.364443,41.917643],[19.36353,41.917141],[19.361704,41.916513],[19.358964,41.915949],[19.355727,41.915447],[19.352074,41.914631],[19.3495,41.91413],[19.348172,41.913502],[19.346097,41.912875],[19.344769,41.91231],[19.343689,41.911432],[19.342527,41.910428],[19.342195,41.909989],[19.341614,41.908232],[19.341863,41.907291],[19.342029,41.90635],[19.342527,41.905409],[19.343025,41.904908],[19.345931,41.903088],[19.348919,41.901896],[19.351576,41.900892],[19.353153,41.900516],[19.355477,41.900453],[19.358881,41.899951],[19.361288,41.899638],[19.362119,41.899324],[19.363779,41.89876],[19.36519,41.898007],[19.365937,41.897003],[19.366269,41.895999],[19.366435,41.894807],[19.366599,41.894063],[19.366767,41.893302],[19.36685,41.891859],[19.366933,41.890918],[19.367093,41.890156],[19.36702,41.889875],[19.367146,41.889581],[19.368014,41.888502],[19.370212,41.887572],[19.377311,41.887319],[19.380081,41.886259],[19.380184,41.88622],[19.380775,41.885291],[19.380353,41.884023],[19.37957,41.883083],[19.375367,41.878614],[19.373491,41.878145],[19.373306,41.877918],[19.367472,41.875389],[19.358305,41.874554],[19.355,41.872917],[19.35161,41.872917],[19.34664,41.870388],[19.341667,41.870445],[19.340778,41.869556],[19.337473,41.869583],[19.336666,41.868778],[19.334972,41.868752],[19.332916,41.870834],[19.331194,41.875832],[19.327499,41.879612],[19.324167,41.881279],[19.322472,41.881248],[19.318333,41.884583],[19.3125,41.888779],[19.305805,41.892113],[19.301666,41.892887],[19.300806,41.893749],[19.295834,41.893723],[19.294945,41.894585],[19.290833,41.894585],[19.288334,41.896252],[19.286638,41.896278],[19.283306,41.897945],[19.281666,41.899582],[19.276695,41.902084],[19.268333,41.902916],[19.267471,41.903778],[19.263334,41.903778],[19.262472,41.904556],[19.259945,41.904583],[19.259138,41.905418],[19.255777,41.905418],[19.254999,41.906277],[19.247473,41.907082],[19.244139,41.908749],[19.236639,41.908749],[19.23625,41.910831],[19.239944,41.91375],[19.245001,41.913723],[19.248306,41.915443],[19.252445,41.91539],[19.253305,41.914585],[19.254999,41.914555],[19.255806,41.915443],[19.260778,41.915443],[19.261612,41.916279],[19.26664,41.917084],[19.267471,41.917946],[19.275,41.91711],[19.275862,41.916248],[19.279972,41.919582],[19.281666,41.919613],[19.283306,41.921276],[19.285833,41.921276],[19.288305,41.92289],[19.294138,41.922943],[19.295,41.922085],[19.298277,41.922085],[19.300028,41.922916],[19.302917,41.926666],[19.302473,41.92878],[19.301666,41.927891],[19.299194,41.928722],[19.294195,41.92625],[19.284166,41.926277],[19.283278,41.925388],[19.279972,41.925415],[19.278305,41.924583],[19.272472,41.919582],[19.26825,41.919582],[19.267529,41.918751],[19.264999,41.918777],[19.264166,41.917915],[19.261639,41.917915],[19.260834,41.917057],[19.253334,41.916248],[19.252472,41.91711],[19.250778,41.917084],[19.249971,41.916248],[19.245832,41.916248],[19.242445,41.914612],[19.23914,41.914612],[19.236666,41.912918],[19.234556,41.911667],[19.235416,41.910831],[19.235445,41.907528],[19.237083,41.905834],[19.234972,41.904583],[19.234167,41.90625],[19.229555,41.91],[19.22961,41.910862],[19.225805,41.912056],[19.224167,41.91375],[19.220833,41.914555],[19.21911,41.916248],[19.216667,41.916248],[19.214083,41.917946],[19.212473,41.917915],[19.210833,41.919613],[19.20414,41.920418],[19.203777,41.922527],[19.203306,41.922916],[19.202473,41.922112],[19.200806,41.922085],[19.197472,41.92625],[19.196638,41.925446],[19.193361,41.925388],[19.190777,41.927055],[19.18664,41.927113],[19.185028,41.927944],[19.181639,41.931278],[19.176611,41.93211],[19.175444,41.933334],[19.176195,41.934166],[19.174139,41.936249],[19.173334,41.934639],[19.170805,41.934582],[19.167055,41.9375],[19.166639,41.938751],[19.163279,41.940472],[19.160833,41.940418],[19.16,41.942944],[19.155806,41.945446],[19.154972,41.947083],[19.152527,41.947109],[19.150806,41.947945],[19.14875,41.950027],[19.148695,41.952473],[19.147055,41.953304],[19.147028,41.954166],[19.152472,41.954582],[19.153334,41.953751],[19.159973,41.952084],[19.161667,41.951248],[19.163723,41.952499],[19.162083,41.955833],[19.158306,41.95961],[19.154972,41.960415],[19.151222,41.963333],[19.151251,41.964973],[19.149973,41.966278],[19.147444,41.966305],[19.145805,41.967918],[19.143305,41.96875],[19.13961,41.972527],[19.138695,41.975029],[19.137028,41.976696],[19.137056,41.978359],[19.140028,41.98214],[19.145834,41.982113],[19.146639,41.981277],[19.149166,41.981251],[19.149944,41.982918],[19.151251,41.983334],[19.151222,41.984196],[19.147499,41.988777],[19.139528,41.99086],[19.139944,41.992085],[19.14539,41.995029],[19.144527,41.995861],[19.144751,42.0],[19.146194,42.000751],[19.143278,42.002804],[19.142,42.00489],[19.144556,42.006554],[19.1495,42.013248],[19.148251,42.0145],[19.146639,42.014473],[19.144112,42.016998],[19.140333,42.017387],[19.140333,42.019917],[19.146139,42.023224],[19.147055,42.026611],[19.144972,42.026974],[19.140751,42.029472],[19.139055,42.029446],[19.137888,42.03075],[19.137833,42.032391],[19.140333,42.033249],[19.1395,42.035694],[19.140333,42.038223],[19.142,42.039055],[19.142,42.042362],[19.139944,42.044445],[19.133249,42.04697],[19.129084,42.05114],[19.126612,42.05114],[19.119139,42.056973],[19.115749,42.057777],[19.111973,42.060749],[19.111639,42.062],[19.109945,42.061974],[19.104111,42.064445],[19.101555,42.067833],[19.097473,42.068638],[19.094944,42.071167],[19.092472,42.07111],[19.091612,42.071972],[19.089083,42.071972],[19.085306,42.07489],[19.086195,42.076557],[19.084917,42.077805],[19.082472,42.077805],[19.078278,42.081112],[19.076584,42.082001],[19.074112,42.081974],[19.069529,42.089085],[19.070807,42.090305],[19.071583,42.089474],[19.074972,42.089474],[19.075361,42.091526],[19.076584,42.091946],[19.077833,42.090721],[19.077473,42.087776],[19.08239,42.087807],[19.08325,42.086971],[19.084167,42.087776],[19.086611,42.087833],[19.089472,42.08989],[19.092056,42.095749],[19.091167,42.099918],[19.088722,42.107361],[19.086195,42.109055],[19.085777,42.110306],[19.084944,42.110279],[19.08411,42.111973],[19.081638,42.112804],[19.077389,42.116165],[19.075777,42.116138],[19.069111,42.120304],[19.067444,42.122002],[19.062834,42.122391],[19.063667,42.12989],[19.061583,42.132832],[19.059111,42.13364],[19.055805,42.136082],[19.04911,42.136166],[19.048222,42.135277],[19.041611,42.135277],[19.03825,42.136944],[19.036583,42.136971],[19.035749,42.136082],[19.032389,42.135307],[19.029972,42.136971],[19.029499,42.134918],[19.02739,42.133667],[19.024889,42.139446],[19.019056,42.139473],[19.014084,42.13361],[19.011639,42.13361],[19.009472,42.138222],[19.006166,42.141529],[19.006166,42.144054],[19.003695,42.146526],[19.002806,42.149887],[19.005333,42.155693],[19.0,42.159443],[18.993279,42.158695],[18.990833,42.162888],[18.986639,42.162083],[18.985806,42.164585],[18.97661,42.167889],[18.974167,42.170361],[18.972473,42.170387],[18.970028,42.172085],[18.967945,42.174999],[18.96789,42.179111],[18.971277,42.183304],[18.970417,42.188332],[18.967501,42.19125],[18.965,42.192055],[18.961695,42.194557],[18.958279,42.195415],[18.957472,42.194557],[18.956667,42.195389],[18.95414,42.195415],[18.952055,42.197498],[18.950806,42.20039],[18.946667,42.200417],[18.943333,42.203724],[18.939972,42.205387],[18.939138,42.204582],[18.937445,42.204556],[18.936666,42.205387],[18.932501,42.205418],[18.931694,42.204556],[18.929972,42.205387],[18.927111,42.208305],[18.92625,42.210804],[18.924973,42.212029],[18.923277,42.212055],[18.922472,42.212917],[18.918333,42.212891],[18.915777,42.215416],[18.912527,42.216221],[18.907084,42.220806],[18.906221,42.223305],[18.907055,42.225777],[18.905445,42.228333],[18.905416,42.23164],[18.904167,42.233723],[18.899944,42.233723],[18.899584,42.235832],[18.897083,42.236694],[18.897028,42.238304],[18.898695,42.239113],[18.899529,42.241665],[18.896194,42.244972],[18.896223,42.248333],[18.897861,42.249973],[18.897055,42.251667],[18.894167,42.254528],[18.891251,42.255001],[18.891222,42.255806],[18.893694,42.257446],[18.892471,42.259609],[18.891222,42.259972],[18.892111,42.268333],[18.889584,42.27],[18.888306,42.27375],[18.885,42.27375],[18.884111,42.274529],[18.8825,42.274555],[18.881222,42.275806],[18.882084,42.277473],[18.879944,42.279556],[18.865862,42.279583],[18.862888,42.278332],[18.862499,42.276249],[18.860806,42.276222],[18.858723,42.278305],[18.858723,42.280804],[18.856611,42.282082],[18.856251,42.283333],[18.853306,42.283749],[18.852501,42.284584],[18.848362,42.284557],[18.847473,42.283695],[18.844999,42.283749],[18.843334,42.28286],[18.841194,42.279972],[18.840389,42.276638],[18.839167,42.276222],[18.838362,42.275391],[18.834167,42.276249],[18.831667,42.272861],[18.828278,42.272861],[18.825834,42.276249],[18.8225,42.277054],[18.817499,42.28125],[18.815805,42.281193],[18.813334,42.283722],[18.810806,42.283749],[18.803694,42.279945],[18.803778,42.2775],[18.805389,42.275806],[18.805389,42.273277],[18.804193,42.272057],[18.80164,42.274582],[18.79911,42.274529],[18.798306,42.275391],[18.796694,42.275417],[18.796249,42.276669],[18.794138,42.277889],[18.791611,42.277889],[18.788305,42.279583],[18.787083,42.275002],[18.787861,42.272499],[18.789528,42.270805],[18.78875,42.269138],[18.783306,42.266224],[18.78161,42.266251],[18.780806,42.267113],[18.777416,42.267082],[18.776638,42.26786],[18.775778,42.267918],[18.769945,42.27375],[18.769112,42.273724],[18.767471,42.276222],[18.763334,42.277916],[18.761639,42.280388],[18.759111,42.282055],[18.755833,42.282917],[18.754555,42.284138],[18.754583,42.285805],[18.751223,42.287445],[18.750444,42.290001],[18.749166,42.291248],[18.745806,42.292027],[18.74375,42.295834],[18.738306,42.299557],[18.737888,42.300804],[18.736666,42.302082],[18.735777,42.301224],[18.733305,42.301224],[18.732027,42.302502],[18.731667,42.304554],[18.729111,42.304554],[18.726667,42.306252],[18.724527,42.309971],[18.719555,42.313305],[18.71911,42.314556],[18.713306,42.317917],[18.710833,42.320389],[18.707056,42.322498],[18.710417,42.324944],[18.711666,42.327026],[18.713278,42.327084],[18.714167,42.326221],[18.713694,42.328278],[18.709583,42.333279],[18.70875,42.339169],[18.706583,42.341251],[18.704971,42.341251],[18.703333,42.342083],[18.700806,42.345417],[18.696667,42.34539],[18.695389,42.346611],[18.69536,42.34914],[18.691639,42.352085],[18.689138,42.35289],[18.687056,42.354973],[18.687056,42.356693],[18.688334,42.357918],[18.699972,42.356251],[18.70414,42.353779],[18.707056,42.354168],[18.704166,42.355362],[18.701279,42.358334],[18.700361,42.359974],[18.700361,42.364166],[18.696638,42.367054],[18.689583,42.369999],[18.688694,42.37336],[18.691223,42.375805],[18.685806,42.38039],[18.684973,42.38036],[18.685389,42.383305],[18.684111,42.384583],[18.682888,42.384167],[18.681667,42.382084],[18.6775,42.382057],[18.676611,42.382889],[18.674139,42.382889],[18.672501,42.38372],[18.669971,42.385387],[18.665806,42.385418],[18.665001,42.38625],[18.664194,42.385387],[18.661638,42.385387],[18.660833,42.384583],[18.657499,42.384556],[18.656639,42.382889],[18.653749,42.381611],[18.653749,42.375778],[18.656639,42.374584],[18.658722,42.372471],[18.656639,42.370419],[18.655027,42.370445],[18.653749,42.369167],[18.653723,42.365833],[18.655001,42.362888],[18.653334,42.362057],[18.65,42.36211],[18.646639,42.36375],[18.644945,42.363724],[18.643723,42.364944],[18.643723,42.367474],[18.641666,42.368752],[18.637501,42.368721],[18.636612,42.367889],[18.634167,42.369556],[18.632,42.369167],[18.632444,42.367916],[18.634583,42.366638],[18.634501,42.36414],[18.6325,42.362083],[18.630833,42.361252],[18.628305,42.361195],[18.62414,42.362888],[18.621611,42.362888],[18.618279,42.365391],[18.609167,42.363724],[18.609167,42.367889],[18.607445,42.367916],[18.606667,42.368752],[18.602501,42.368721],[18.601667,42.367916],[18.600389,42.369141],[18.600416,42.370861],[18.59664,42.37289],[18.590778,42.374611],[18.590416,42.378307],[18.591278,42.379971],[18.588333,42.38039],[18.587418,42.379555],[18.585806,42.379528],[18.583723,42.383305],[18.579195,42.387054],[18.575834,42.386223],[18.572889,42.388279],[18.570389,42.391666],[18.570444,42.394138],[18.571695,42.395416],[18.575027,42.395416],[18.576666,42.394554],[18.576221,42.395805],[18.57625,42.397499],[18.578722,42.399166],[18.578306,42.400417],[18.574972,42.400391],[18.574083,42.401249],[18.565805,42.402084],[18.565001,42.402863],[18.562471,42.402889],[18.560806,42.403694],[18.557056,42.406639],[18.556223,42.410805],[18.557501,42.411221],[18.557472,42.412029],[18.553305,42.412056],[18.5525,42.412888],[18.549944,42.412918],[18.54789,42.414165],[18.54789,42.416637],[18.545444,42.421665],[18.549166,42.425415],[18.555,42.426224],[18.557501,42.431252],[18.559111,42.431221],[18.559944,42.43211],[18.5625,42.432026],[18.563305,42.432919],[18.5725,42.432888],[18.573305,42.432026],[18.576611,42.432056],[18.58,42.430416],[18.584167,42.430389],[18.584972,42.429554],[18.5875,42.429585],[18.588306,42.428749],[18.596611,42.427891],[18.6,42.42625],[18.602472,42.426193],[18.605833,42.424557],[18.610001,42.424583],[18.610806,42.423752],[18.613277,42.423721],[18.615805,42.422085],[18.620028,42.421249],[18.625,42.417915],[18.627472,42.417915],[18.628277,42.417057],[18.632473,42.416248],[18.638361,42.413723],[18.642471,42.412888],[18.645805,42.410389],[18.649973,42.410362],[18.650778,42.409527],[18.658306,42.408779],[18.659166,42.407917],[18.661638,42.40786],[18.664194,42.406193],[18.666639,42.40625],[18.667444,42.405418],[18.67,42.405388],[18.670805,42.404556],[18.673277,42.404556],[18.674139,42.403778],[18.674973,42.40453],[18.687529,42.405418],[18.688305,42.404583],[18.689945,42.40461],[18.690805,42.403751],[18.694139,42.403721],[18.697472,42.401222],[18.700388,42.397499],[18.705,42.393749],[18.706694,42.393723],[18.7075,42.392887],[18.70875,42.394165],[18.709583,42.399166],[18.707083,42.401695],[18.708279,42.402916],[18.709972,42.402889],[18.710388,42.404167],[18.707445,42.404556],[18.707027,42.405804],[18.708305,42.406223],[18.709139,42.407055],[18.710028,42.406193],[18.712473,42.40625],[18.713751,42.407471],[18.713722,42.410805],[18.712917,42.41164],[18.713722,42.41497],[18.712473,42.417057],[18.709139,42.417915],[18.708778,42.419167],[18.7075,42.420387],[18.705805,42.420418],[18.700001,42.427055],[18.697445,42.427055],[18.695807,42.427891],[18.692862,42.43],[18.692055,42.433304],[18.689167,42.437916],[18.68375,42.438332],[18.687111,42.441666],[18.686222,42.442501],[18.685389,42.448307],[18.682888,42.451637],[18.68125,42.455776],[18.682888,42.464169],[18.685389,42.467472],[18.687027,42.474998],[18.689972,42.477055],[18.690805,42.477859],[18.693277,42.477917],[18.696638,42.476276],[18.701611,42.475418],[18.702417,42.474556],[18.704111,42.474583],[18.705,42.473751],[18.7125,42.473721],[18.714945,42.472057],[18.72164,42.471222],[18.728306,42.467861],[18.729973,42.467056],[18.734138,42.467083],[18.737499,42.463696],[18.740805,42.462055],[18.746611,42.457085],[18.748333,42.457054],[18.751194,42.45414],[18.752861,42.450806],[18.754194,42.450359],[18.755388,42.449139],[18.755417,42.444168],[18.757055,42.441612],[18.755388,42.438332],[18.756639,42.437889],[18.759611,42.434971],[18.761194,42.429165],[18.761278,42.427471],[18.760361,42.42664],[18.763334,42.423721],[18.76664,42.422085],[18.769583,42.423332],[18.767084,42.426666],[18.767,42.430832],[18.765388,42.434971],[18.762028,42.440807],[18.763779,42.448334],[18.765388,42.452473],[18.765333,42.458305],[18.76375,42.461639],[18.763779,42.467472],[18.762833,42.469971],[18.76375,42.470806],[18.76375,42.474972],[18.762861,42.475807],[18.762917,42.480835],[18.765388,42.485001],[18.765417,42.48661],[18.763721,42.488304],[18.762501,42.490391],[18.761694,42.489582],[18.754972,42.489555],[18.750805,42.487083],[18.744944,42.484554],[18.743305,42.484585],[18.7425,42.483696],[18.740028,42.483723],[18.73914,42.482887],[18.735806,42.482887],[18.734972,42.482082],[18.73336,42.482029],[18.729973,42.483749],[18.727501,42.483749],[18.72661,42.482887],[18.723278,42.482861],[18.7225,42.483723],[18.720806,42.482944],[18.709139,42.482861],[18.708361,42.483723],[18.700001,42.483723],[18.696611,42.485363],[18.691223,42.493332],[18.691223,42.50161],[18.69375,42.504971],[18.69375,42.506638],[18.695389,42.510777],[18.693333,42.513721],[18.691639,42.513748],[18.689112,42.515415],[18.68836,42.514584],[18.685806,42.514526],[18.683306,42.511223],[18.682444,42.511223],[18.679138,42.507027],[18.677917,42.506668],[18.677444,42.504581],[18.675777,42.503693],[18.669971,42.50375],[18.669167,42.502888],[18.665001,42.500389],[18.661638,42.499584],[18.65661,42.495419],[18.654139,42.495361],[18.651222,42.490776],[18.653305,42.488724],[18.658333,42.488724],[18.65914,42.487915],[18.665777,42.487888],[18.666666,42.487057],[18.669971,42.487057],[18.672527,42.48539],[18.6775,42.484585],[18.680805,42.482887],[18.684999,42.482056],[18.685806,42.481194],[18.6875,42.481224],[18.688723,42.479946],[18.688778,42.478359],[18.686251,42.475777],[18.68461,42.471638],[18.682444,42.469528],[18.679193,42.467918],[18.677029,42.465805],[18.677917,42.464973],[18.67786,42.459999],[18.676584,42.458721],[18.673306,42.457916],[18.669138,42.45536],[18.666666,42.455418],[18.665777,42.454556],[18.657499,42.448723],[18.651638,42.448776],[18.649918,42.447083],[18.644138,42.444557],[18.642445,42.442917],[18.640806,42.44289],[18.638334,42.441223],[18.634167,42.441193],[18.630777,42.438721],[18.628305,42.438751],[18.627501,42.437862],[18.624083,42.437916],[18.623362,42.437027],[18.619972,42.437084],[18.619139,42.436279],[18.613306,42.43539],[18.609972,42.433723],[18.599972,42.432888],[18.599167,42.433723],[18.595778,42.433723],[18.592445,42.436222],[18.585806,42.437916],[18.573334,42.447083],[18.567499,42.452057],[18.563334,42.452084],[18.559999,42.45039],[18.555861,42.447918],[18.553305,42.447918],[18.552473,42.447029],[18.550777,42.447056],[18.549973,42.447887],[18.545805,42.447918],[18.544916,42.448776],[18.541611,42.44875],[18.540806,42.447887],[18.535,42.447918],[18.534195,42.44875],[18.531639,42.448696],[18.529972,42.45039],[18.527472,42.451195],[18.526611,42.452888],[18.520779,42.456196],[18.51664,42.457085],[18.515833,42.456249],[18.512444,42.456249],[18.511694,42.455418],[18.51,42.455387],[18.50625,42.452446],[18.505388,42.450832],[18.506195,42.449974],[18.50625,42.446609],[18.507889,42.444195],[18.50835,42.443638],[18.512444,42.438751],[18.515028,42.437889],[18.519972,42.433693],[18.522444,42.431252],[18.525778,42.429527],[18.527472,42.429585],[18.528786,42.428294],[18.529124,42.427776],[18.530083,42.423766],[18.529996,42.423505],[18.529429,42.423451],[18.528434,42.423355],[18.5259,42.423113],[18.525333,42.421631],[18.524548,42.420585],[18.522544,42.42137]]],[[[19.363644,41.848729],[19.341732,41.86205],[19.339872,41.863402],[19.338351,41.864755],[19.338943,41.866276],[19.339785,41.866215],[19.339863,41.866539],[19.341393,41.867374],[19.344605,41.868896],[19.345265,41.869016],[19.347394,41.869403],[19.348356,41.869474],[19.358718,41.870248],[19.369282,41.872529],[19.373113,41.874525],[19.373695,41.874168],[19.373722,41.867474],[19.373419,41.864653],[19.373419,41.864652],[19.37266,41.861591],[19.370972,41.856895],[19.371057,41.855627],[19.371479,41.854444],[19.371648,41.853261],[19.371651,41.851926],[19.370527,41.848891],[19.369282,41.847514],[19.367268,41.846345],[19.365003,41.847903],[19.363644,41.848729]]],[[[18.936611,42.199554],[18.9375,42.198723],[18.938334,42.198723],[18.938723,42.196609],[18.937445,42.195389],[18.934973,42.195415],[18.934584,42.195862],[18.93461,42.197472],[18.936611,42.199554]]],[[[18.93786,42.191639],[18.936666,42.190418],[18.935806,42.19125],[18.934111,42.191223],[18.933722,42.191666],[18.934111,42.193722],[18.935806,42.193695],[18.93786,42.191639]]],[[[18.894972,42.249584],[18.893278,42.249554],[18.892944,42.25],[18.892889,42.251667],[18.893333,42.252056],[18.894945,42.252083],[18.895416,42.25164],[18.895416,42.249973],[18.894972,42.249584]]],[[[18.859583,42.260029],[18.858334,42.257946],[18.855806,42.260387],[18.853306,42.261223],[18.847055,42.268307],[18.847473,42.269554],[18.849167,42.269611],[18.856667,42.264584],[18.859583,42.260029]]],[[[18.846222,42.268333],[18.845028,42.267056],[18.843334,42.267082],[18.842945,42.267471],[18.84289,42.268333],[18.844999,42.27039],[18.845833,42.27039],[18.846222,42.269943],[18.846222,42.268333]]],[[[18.705833,42.404583],[18.702444,42.404556],[18.70211,42.405029],[18.702444,42.406223],[18.705862,42.40625],[18.706249,42.405777],[18.705833,42.404583]]],[[[18.703278,42.330418],[18.701666,42.330387],[18.699528,42.332474],[18.699972,42.334583],[18.701666,42.334557],[18.702888,42.333332],[18.702944,42.331665],[18.703751,42.330833],[18.703278,42.330418]]],[[[18.702,42.327473],[18.701639,42.327057],[18.699944,42.327084],[18.69875,42.328335],[18.700001,42.329556],[18.700777,42.329556],[18.702055,42.328335],[18.702,42.327473]]],[[[18.692499,42.412888],[18.694111,42.410416],[18.697527,42.410416],[18.700806,42.408779],[18.701221,42.408306],[18.699944,42.407082],[18.696638,42.407082],[18.695833,42.40786],[18.694944,42.407055],[18.693306,42.407082],[18.691639,42.408749],[18.688305,42.408749],[18.687445,42.409584],[18.683277,42.409557],[18.682945,42.41],[18.684111,42.412083],[18.689112,42.412083],[18.690027,42.412888],[18.692499,42.412888]]],[[[18.666611,42.365417],[18.665001,42.365391],[18.663723,42.366665],[18.664194,42.368752],[18.665806,42.368721],[18.667944,42.3675],[18.667889,42.366638],[18.666611,42.365417]]],[[[18.559139,42.397083],[18.560417,42.395805],[18.559999,42.394585],[18.557472,42.394527],[18.557056,42.394974],[18.557472,42.396252],[18.558306,42.396221],[18.559139,42.397083]]],[[[18.540806,42.40625],[18.540028,42.406223],[18.53875,42.407471],[18.538723,42.408306],[18.539972,42.409557],[18.540833,42.409557],[18.542028,42.408333],[18.542055,42.407471],[18.540806,42.40625]]]],"type":"MultiPolygon"}
+  ],
+  "geometry": {"coordinates":[[[[18.522544,42.42137],[18.516748,42.426381],[18.512617,42.427998],[18.508022,42.430298],[18.503369,42.432816],[18.499521,42.435768],[18.496993,42.438069],[18.492168,42.442887],[18.490215,42.445622],[18.488319,42.447575],[18.48562,42.449659],[18.483896,42.451439],[18.48292,42.452307],[18.480565,42.455563],[18.478095,42.458384],[18.47551,42.460902],[18.472121,42.463723],[18.469077,42.466024],[18.465975,42.468238],[18.463447,42.469497],[18.460633,42.470408],[18.457301,42.471233],[18.454544,42.471667],[18.452878,42.472232],[18.45127,42.473056],[18.448742,42.47527],[18.445698,42.477788],[18.443745,42.479351],[18.441907,42.480392],[18.438862,42.481695],[18.435646,42.482823],[18.43398,42.483605],[18.43668,42.489031],[18.438805,42.493242],[18.440643,42.497105],[18.440356,42.498624],[18.440758,42.500057],[18.441348,42.501699],[18.441923,42.50296],[18.442959,42.504394],[18.444052,42.505785],[18.445029,42.506959],[18.446237,42.508263],[18.44687,42.509219],[18.445432,42.510566],[18.442153,42.514565],[18.440083,42.516826],[18.43853,42.51913],[18.437667,42.520477],[18.438012,42.524433],[18.437782,42.52591],[18.438415,42.532083],[18.438472,42.534169],[18.43853,42.537647],[18.439047,42.540255],[18.439565,42.542167],[18.440198,42.543515],[18.440428,42.544862],[18.440428,42.548166],[18.440198,42.549557],[18.438932,42.552774],[18.437955,42.555555],[18.437756,42.55653],[18.441639,42.557076],[18.44471,42.557485],[18.447238,42.557758],[18.449857,42.557963],[18.452295,42.558714],[18.455004,42.559533],[18.456901,42.56042],[18.458707,42.560966],[18.460423,42.561716],[18.463854,42.56274],[18.46548,42.563081],[18.468369,42.564173],[18.470808,42.56547],[18.473155,42.567039],[18.475413,42.568131],[18.476587,42.569018],[18.479206,42.570179],[18.48056,42.570861],[18.482096,42.572294],[18.483721,42.574068],[18.485166,42.575775],[18.486972,42.577754],[18.488417,42.579528],[18.489771,42.580893],[18.491126,42.582326],[18.493113,42.584373],[18.494648,42.585465],[18.496815,42.586625],[18.499705,42.587649],[18.502143,42.588331],[18.504401,42.588468],[18.506026,42.588263],[18.508826,42.587649],[18.510541,42.586898],[18.513431,42.586284],[18.516592,42.585806],[18.518308,42.585704],[18.521017,42.585329],[18.523726,42.584646],[18.526345,42.583827],[18.528422,42.58294],[18.530499,42.581507],[18.532395,42.579528],[18.534291,42.577958],[18.535827,42.576935],[18.537362,42.575502],[18.538716,42.57441],[18.541787,42.574887],[18.544315,42.576116],[18.546573,42.577344],[18.550275,42.578846],[18.552713,42.580006],[18.553797,42.580756],[18.553887,42.582053],[18.552713,42.585806],[18.552352,42.588604],[18.551901,42.590993],[18.551359,42.593108],[18.550546,42.594132],[18.549192,42.595088],[18.547566,42.596316],[18.544044,42.597886],[18.542238,42.598977],[18.540884,42.600001],[18.539619,42.60082],[18.538626,42.601571],[18.537091,42.60198],[18.534833,42.602594],[18.53384,42.602731],[18.534201,42.604232],[18.534472,42.605256],[18.53384,42.607576],[18.533208,42.608736],[18.532576,42.60976],[18.532034,42.610784],[18.53104,42.611125],[18.530499,42.611944],[18.529686,42.613445],[18.529325,42.614128],[18.52788,42.614946],[18.525983,42.616448],[18.524719,42.617403],[18.524087,42.618563],[18.523997,42.619246],[18.525442,42.621088],[18.527248,42.623613],[18.527789,42.62491],[18.529054,42.626548],[18.529957,42.628117],[18.530408,42.629278],[18.531943,42.630574],[18.533298,42.631803],[18.535646,42.633782],[18.537542,42.635215],[18.53971,42.636511],[18.540432,42.636853],[18.543773,42.637535],[18.54567,42.638081],[18.547024,42.638422],[18.550998,42.639992],[18.553797,42.640947],[18.557319,42.64163],[18.56075,42.642585],[18.564995,42.643199],[18.567614,42.642995],[18.569058,42.643268],[18.571316,42.642926],[18.573574,42.642449],[18.575831,42.64238],[18.576825,42.642926],[18.576734,42.64395],[18.575831,42.646612],[18.574657,42.649205],[18.573664,42.651184],[18.572851,42.65289],[18.572039,42.654869],[18.571587,42.655347],[18.570232,42.655756],[18.566711,42.656916],[18.56662,42.658349],[18.566801,42.660465],[18.56644,42.661762],[18.565898,42.662171],[18.562195,42.663399],[18.559938,42.66415],[18.558673,42.664764],[18.556687,42.666334],[18.554068,42.66845],[18.551991,42.670156],[18.551178,42.670702],[18.550727,42.671384],[18.551088,42.673636],[18.551901,42.675479],[18.551991,42.677185],[18.551991,42.67855],[18.55172,42.679846],[18.550546,42.681894],[18.550004,42.683395],[18.549553,42.684623],[18.549011,42.685442],[18.548559,42.686466],[18.548018,42.687558],[18.548018,42.689127],[18.547927,42.690424],[18.547747,42.691175],[18.548559,42.691516],[18.549553,42.691243],[18.551359,42.690629],[18.553075,42.690629],[18.554158,42.690833],[18.555061,42.692403],[18.555513,42.693631],[18.555964,42.694519],[18.557138,42.697317],[18.558312,42.698954],[18.56048,42.700592],[18.562286,42.701957],[18.563369,42.702844],[18.56346,42.704619],[18.563279,42.705574],[18.563279,42.707075],[18.563279,42.708099],[18.56364,42.708986],[18.564092,42.710146],[18.565175,42.71158],[18.566349,42.712467],[18.567072,42.713968],[18.567252,42.715606],[18.567252,42.716698],[18.567523,42.718609],[18.567162,42.720246],[18.566981,42.721475],[18.563098,42.722976],[18.559215,42.724273],[18.557409,42.724887],[18.556055,42.724478],[18.555152,42.724136],[18.553887,42.723113],[18.553165,42.722362],[18.552804,42.721748],[18.55181,42.721475],[18.548469,42.721202],[18.544405,42.721407],[18.541425,42.721748],[18.53971,42.722226],[18.536459,42.723181],[18.535285,42.72359],[18.533569,42.723727],[18.532305,42.723795],[18.530047,42.723863],[18.528241,42.724682],[18.524448,42.726661],[18.523184,42.727685],[18.522642,42.727958],[18.522191,42.728845],[18.520565,42.729801],[18.519301,42.730961],[18.517314,42.733076],[18.51596,42.734919],[18.513702,42.734987],[18.510812,42.73526],[18.509638,42.73526],[18.508284,42.735328],[18.506839,42.73526],[18.503769,42.734782],[18.499344,42.73758],[18.499976,42.738741],[18.500879,42.740993],[18.501511,42.742289],[18.50133,42.743518],[18.500156,42.744064],[18.499163,42.744951],[18.497538,42.745428],[18.496002,42.74652],[18.494558,42.747612],[18.493925,42.748909],[18.492751,42.749591],[18.491668,42.750137],[18.488868,42.750342],[18.486791,42.750751],[18.485076,42.751502],[18.48327,42.751912],[18.481463,42.752116],[18.480289,42.752662],[18.478393,42.753345],[18.476406,42.753686],[18.47442,42.75471],[18.473517,42.755938],[18.472885,42.756825],[18.472885,42.757712],[18.472885,42.759282],[18.472433,42.761329],[18.47153,42.762694],[18.47153,42.763718],[18.473426,42.765083],[18.47442,42.765902],[18.474329,42.766652],[18.47451,42.767266],[18.475413,42.768563],[18.475865,42.76986],[18.475594,42.770542],[18.476587,42.771361],[18.477039,42.77177],[18.476226,42.772112],[18.475323,42.772248],[18.47451,42.772385],[18.474149,42.773272],[18.474871,42.77375],[18.476226,42.77375],[18.476948,42.773408],[18.476406,42.774295],[18.476677,42.774841],[18.475594,42.775114],[18.47451,42.775319],[18.473426,42.775729],[18.472433,42.776479],[18.471349,42.777571],[18.470627,42.778663],[18.470537,42.780437],[18.470175,42.782075],[18.469724,42.783099],[18.469995,42.784464],[18.470356,42.785897],[18.470266,42.786784],[18.469724,42.78774],[18.468098,42.788012],[18.466654,42.788558],[18.464757,42.790469],[18.464306,42.791698],[18.465209,42.792926],[18.466563,42.794223],[18.467105,42.79511],[18.467557,42.796543],[18.468008,42.797567],[18.46864,42.798659],[18.469092,42.799614],[18.469092,42.800979],[18.469724,42.801456],[18.470266,42.801729],[18.468731,42.802958],[18.467557,42.804323],[18.466654,42.805961],[18.467376,42.806848],[18.466744,42.807871],[18.466383,42.809168],[18.466202,42.81026],[18.466021,42.811557],[18.466112,42.81258],[18.46566,42.813126],[18.464306,42.813877],[18.463764,42.815242],[18.463132,42.81688],[18.462319,42.818654],[18.461687,42.819405],[18.461506,42.820224],[18.460964,42.820906],[18.459971,42.82152],[18.462409,42.822885],[18.465751,42.824182],[18.469182,42.825615],[18.472885,42.826911],[18.475684,42.828003],[18.475413,42.828686],[18.473878,42.829641],[18.472252,42.831006],[18.470717,42.832303],[18.469363,42.833395],[18.468098,42.835032],[18.467195,42.836602],[18.466202,42.838854],[18.466202,42.840697],[18.466563,42.843836],[18.466834,42.846497],[18.467286,42.848545],[18.467557,42.849978],[18.46855,42.851479],[18.470537,42.85339],[18.472433,42.855028],[18.473517,42.856051],[18.474962,42.857758],[18.477129,42.859532],[18.478845,42.860965],[18.479567,42.861374],[18.481373,42.860829],[18.48345,42.859941],[18.484985,42.859259],[18.48643,42.858781],[18.487875,42.858781],[18.48932,42.859395],[18.491397,42.860419],[18.492571,42.861716],[18.493925,42.863081],[18.494467,42.863899],[18.49528,42.864855],[18.49537,42.866902],[18.49519,42.868881],[18.494828,42.870587],[18.494196,42.871816],[18.493293,42.873931],[18.492119,42.875774],[18.491307,42.877071],[18.489771,42.878708],[18.494648,42.880414],[18.497538,42.881438],[18.501782,42.882735],[18.506116,42.884168],[18.509819,42.885465],[18.509097,42.88642],[18.507742,42.887717],[18.506207,42.889491],[18.504762,42.892152],[18.503949,42.895087],[18.503407,42.897202],[18.502504,42.899659],[18.501059,42.902798],[18.499795,42.905528],[18.497357,42.909486],[18.49537,42.911807],[18.492842,42.915628],[18.490494,42.91904],[18.488507,42.921975],[18.487243,42.92334],[18.485798,42.925319],[18.485347,42.926888],[18.484985,42.928936],[18.484805,42.931324],[18.485256,42.933713],[18.484985,42.935897],[18.485256,42.939036],[18.485347,42.942584],[18.485708,42.943881],[18.485979,42.94743],[18.486159,42.950091],[18.48643,42.951866],[18.48643,42.954868],[18.487062,42.95869],[18.487514,42.962443],[18.487424,42.963877],[18.488868,42.966197],[18.489952,42.967289],[18.491758,42.969882],[18.49239,42.972271],[18.493384,42.974318],[18.494377,42.977389],[18.49528,42.980187],[18.496093,42.982371],[18.496544,42.983804],[18.496725,42.985305],[18.497176,42.987216],[18.498441,42.989468],[18.499434,42.992129],[18.500066,42.993836],[18.500427,42.994723],[18.502775,42.995951],[18.504581,42.997043],[18.508013,42.999227],[18.509458,42.999909],[18.51027,43.003185],[18.512618,43.007894],[18.515057,43.012603],[18.518037,43.019017],[18.524268,43.022703],[18.531131,43.02632],[18.536188,43.029118],[18.540522,43.031643],[18.547476,43.03137],[18.554339,43.031097],[18.562195,43.030824],[18.574206,43.030482],[18.579263,43.030278],[18.583417,43.030141],[18.588925,43.029936],[18.593892,43.029732],[18.599942,43.029595],[18.604367,43.0298],[18.609786,43.029527],[18.614391,43.029459],[18.620261,43.029322],[18.623241,43.029186],[18.632362,43.031984],[18.637599,43.033553],[18.644643,43.035669],[18.6525,43.038057],[18.663155,43.036829],[18.661891,43.042562],[18.660988,43.04652],[18.660266,43.051228],[18.659724,43.056074],[18.659363,43.058394],[18.659272,43.060441],[18.659001,43.062693],[18.65855,43.064604],[18.657918,43.06515],[18.65846,43.067539],[18.658369,43.070132],[18.658189,43.07177],[18.658369,43.074363],[18.658189,43.077844],[18.657647,43.083985],[18.657376,43.088899],[18.657376,43.09081],[18.657015,43.094359],[18.656654,43.098863],[18.656383,43.102207],[18.656021,43.105414],[18.655299,43.109577],[18.654577,43.11374],[18.653944,43.117903],[18.653222,43.12227],[18.6525,43.125751],[18.651596,43.130937],[18.651145,43.133121],[18.650423,43.137966],[18.649881,43.141856],[18.649339,43.144108],[18.648797,43.147043],[18.650332,43.15025],[18.652138,43.154208],[18.652951,43.156256],[18.653764,43.157825],[18.654757,43.160009],[18.656473,43.163694],[18.657376,43.166765],[18.658189,43.169904],[18.659001,43.172225],[18.659724,43.175023],[18.660717,43.178298],[18.661711,43.181847],[18.662975,43.185942],[18.663607,43.189013],[18.664691,43.191947],[18.665684,43.195223],[18.666497,43.198157],[18.6674,43.201774],[18.668032,43.203685],[18.675437,43.207029],[18.680584,43.209417],[18.682571,43.210168],[18.684919,43.211669],[18.687718,43.213239],[18.691872,43.215764],[18.696207,43.218494],[18.699909,43.220814],[18.703702,43.223339],[18.707946,43.225932],[18.713274,43.229208],[18.717157,43.23187],[18.714268,43.234599],[18.70903,43.238967],[18.704154,43.242584],[18.70018,43.245928],[18.696749,43.248589],[18.694942,43.250022],[18.688421,43.254686],[18.699018,43.260582],[18.70618,43.264631],[18.714507,43.269515],[18.720271,43.272903],[18.725978,43.276423],[18.730228,43.279064],[18.731859,43.28012],[18.73279,43.280516],[18.734013,43.281176],[18.73838,43.282936],[18.743329,43.285004],[18.752005,43.288612],[18.759225,43.291692],[18.767668,43.295213],[18.772268,43.297193],[18.778091,43.299525],[18.785427,43.302209],[18.787465,43.303089],[18.789853,43.304057],[18.79684,43.306389],[18.802197,43.308281],[18.806913,43.309866],[18.810989,43.311318],[18.815939,43.31299],[18.821703,43.31497],[18.826186,43.316466],[18.827642,43.317038],[18.831602,43.318182],[18.83626,43.319502],[18.841151,43.321174],[18.846275,43.323154],[18.852971,43.325707],[18.852738,43.326763],[18.852971,43.327643],[18.852796,43.328611],[18.851865,43.329447],[18.851166,43.330327],[18.8507,43.331119],[18.850642,43.331955],[18.850642,43.333187],[18.850525,43.334375],[18.850118,43.335563],[18.849768,43.336487],[18.848953,43.337147],[18.847963,43.337895],[18.847556,43.338599],[18.847032,43.339259],[18.845984,43.339963],[18.844586,43.340667],[18.84249,43.341724],[18.841384,43.342692],[18.839229,43.344144],[18.839229,43.34476],[18.839753,43.345772],[18.839986,43.347004],[18.839928,43.348324],[18.843363,43.348368],[18.845052,43.348544],[18.846974,43.348852],[18.849477,43.349248],[18.85233,43.349952],[18.854892,43.350656],[18.855708,43.351096],[18.857513,43.351096],[18.858619,43.351272],[18.860133,43.351844],[18.861414,43.351888],[18.862113,43.352108],[18.86287,43.35268],[18.863161,43.353384],[18.863627,43.35378],[18.864733,43.354044],[18.865956,43.354],[18.868285,43.353912],[18.869973,43.353912],[18.871138,43.353868],[18.872361,43.354044],[18.873875,43.354616],[18.876204,43.35554],[18.877252,43.35598],[18.878358,43.356288],[18.879057,43.35642],[18.880629,43.356376],[18.882259,43.356332],[18.883133,43.356244],[18.884297,43.355848],[18.885695,43.355496],[18.886917,43.35532],[18.888082,43.355364],[18.889596,43.355628],[18.891052,43.35576],[18.891925,43.355672],[18.892915,43.3551],[18.893439,43.354572],[18.894254,43.354396],[18.895419,43.35422],[18.896525,43.354132],[18.898039,43.354396],[18.900059,43.3553],[18.901613,43.355979],[18.902079,43.356993],[18.902721,43.35761],[18.903654,43.357962],[18.904762,43.358447],[18.905637,43.358932],[18.907153,43.359372],[18.908669,43.359901],[18.909719,43.360386],[18.910243,43.36043],[18.912459,43.360166],[18.913975,43.359813],[18.914617,43.359461],[18.915083,43.358667],[18.915142,43.357874],[18.91555,43.357301],[18.916775,43.356332],[18.918524,43.355362],[18.919865,43.354745],[18.920798,43.354569],[18.921323,43.353908],[18.922489,43.352013],[18.923131,43.351572],[18.924239,43.351088],[18.926805,43.350118],[18.927738,43.349589],[18.928262,43.348487],[18.928962,43.347033],[18.92972,43.345932],[18.929895,43.344962],[18.930712,43.344257],[18.931645,43.34364],[18.932403,43.343376],[18.934969,43.341481],[18.936718,43.340247],[18.93736,43.339453],[18.937593,43.338704],[18.937943,43.337911],[18.938526,43.337206],[18.939401,43.336897],[18.9401,43.336633],[18.940683,43.336325],[18.941267,43.335531],[18.941558,43.334738],[18.942141,43.334209],[18.942841,43.333945],[18.943949,43.333901],[18.944591,43.33368],[18.94529,43.333196],[18.945698,43.332446],[18.946107,43.331521],[18.946632,43.330948],[18.94739,43.330463],[18.948498,43.330111],[18.949431,43.330287],[18.951297,43.330904],[18.953454,43.331389],[18.955554,43.331389],[18.956312,43.331345],[18.957303,43.331124],[18.958003,43.330728],[18.958586,43.330243],[18.958878,43.329229],[18.959111,43.327731],[18.959344,43.326497],[18.959752,43.325704],[18.960452,43.325131],[18.961093,43.324382],[18.961093,43.323633],[18.960744,43.322884],[18.959985,43.322267],[18.959519,43.321562],[18.959402,43.320856],[18.959519,43.319799],[18.959811,43.318168],[18.959694,43.317022],[18.959286,43.316229],[18.958003,43.3157],[18.956253,43.314863],[18.95497,43.313938],[18.953862,43.313144],[18.952813,43.312175],[18.952055,43.311338],[18.95188,43.31028],[18.951588,43.308297],[18.951005,43.306358],[18.950422,43.305344],[18.950422,43.304551],[18.949197,43.302348],[18.949081,43.301731],[18.949256,43.300893],[18.950714,43.298822],[18.951472,43.297412],[18.952113,43.295958],[18.952988,43.293181],[18.953629,43.292036],[18.953804,43.290802],[18.954679,43.289568],[18.954912,43.288907],[18.955029,43.288202],[18.955612,43.287761],[18.956953,43.287717],[18.958469,43.287849],[18.959519,43.288202],[18.960452,43.288246],[18.961385,43.288069],[18.962726,43.287408],[18.963951,43.287012],[18.966925,43.286747],[18.968383,43.286351],[18.970132,43.285778],[18.972057,43.284588],[18.974214,43.283618],[18.975847,43.283398],[18.977363,43.282957],[18.978879,43.282252],[18.980046,43.281503],[18.981095,43.280886],[18.982087,43.280445],[18.982611,43.279652],[18.983195,43.279344],[18.983661,43.278462],[18.984069,43.276964],[18.984477,43.276083],[18.985702,43.274628],[18.986985,43.273174],[18.98716,43.272205],[18.986985,43.270574],[18.986344,43.268811],[18.98576,43.267754],[18.985352,43.265947],[18.985119,43.264889],[18.984886,43.264184],[18.984652,43.263391],[18.984827,43.26273],[18.985411,43.262069],[18.986985,43.26154],[18.988676,43.260879],[18.990484,43.260174],[18.991825,43.259557],[18.9934,43.25797],[18.995382,43.256516],[18.997015,43.255194],[18.998473,43.254533],[18.999464,43.253696],[18.999989,43.252991],[19.000631,43.25255],[19.001505,43.252462],[19.00273,43.25233],[19.00378,43.252638],[19.004829,43.253431],[19.005412,43.254048],[19.00897,43.258499],[19.012468,43.262333],[19.013343,43.263655],[19.016784,43.269693],[19.018416,43.271984],[19.019641,43.274011],[19.023315,43.281768],[19.025472,43.285954],[19.026405,43.289524],[19.028796,43.296046],[19.030313,43.29988],[19.031012,43.301687],[19.031712,43.302965],[19.032703,43.304287],[19.033636,43.305036],[19.034803,43.305917],[19.036202,43.306578],[19.037777,43.307283],[19.039818,43.307856],[19.04215,43.308429],[19.044425,43.308826],[19.049265,43.309443],[19.051947,43.309663],[19.061336,43.309883],[19.071657,43.309927],[19.075331,43.310192],[19.077897,43.3105],[19.07918,43.311117],[19.080113,43.311866],[19.080754,43.312836],[19.080813,43.313629],[19.080521,43.314687],[19.079355,43.316229],[19.075506,43.321209],[19.07294,43.32469],[19.070666,43.327158],[19.069616,43.328613],[19.068975,43.329979],[19.068742,43.331962],[19.068917,43.334253],[19.069033,43.335399],[19.068625,43.337382],[19.067634,43.339233],[19.066292,43.340467],[19.064485,43.341921],[19.063085,43.34342],[19.062327,43.344654],[19.062036,43.345843],[19.06221,43.347782],[19.062327,43.349325],[19.062152,43.350867],[19.061627,43.352454],[19.060228,43.353732],[19.058653,43.354525],[19.057021,43.355142],[19.052355,43.356332],[19.049498,43.357345],[19.04769,43.358359],[19.045824,43.359901],[19.042267,43.363691],[19.041567,43.364793],[19.040984,43.366996],[19.040576,43.369773],[19.040343,43.372241],[19.039701,43.37418],[19.038535,43.376383],[19.037194,43.378058],[19.035736,43.379688],[19.034103,43.38317],[19.032937,43.388326],[19.031362,43.395641],[19.030954,43.397095],[19.031071,43.398241],[19.032645,43.404323],[19.033053,43.406614],[19.032703,43.408112],[19.032004,43.410404],[19.029496,43.416001],[19.028213,43.418424],[19.023373,43.423713],[19.020457,43.426269],[19.019758,43.427326],[19.018825,43.429574],[19.018591,43.430852],[19.017483,43.431557],[19.016492,43.431733],[19.015792,43.432571],[19.014801,43.432791],[19.014334,43.433187],[19.014334,43.434025],[19.013693,43.43451],[19.011944,43.436404],[19.010661,43.437154],[19.009961,43.437594],[19.009961,43.438784],[19.010544,43.439886],[19.010719,43.440635],[19.010427,43.44112],[19.009728,43.441649],[19.009203,43.441825],[19.008678,43.441384],[19.008328,43.441032],[19.007628,43.441032],[19.007162,43.441472],[19.006929,43.442045],[19.007162,43.442706],[19.007687,43.443367],[19.00862,43.443896],[19.009728,43.444425],[19.010427,43.444866],[19.010894,43.445306],[19.010544,43.445879],[19.009786,43.446056],[19.009203,43.445879],[19.008561,43.446011],[19.008328,43.445549],[19.00757,43.444778],[19.007337,43.444381],[19.00722,43.44394],[19.006608,43.44372],[19.005733,43.444161],[19.005646,43.444822],[19.006287,43.445306],[19.006637,43.445703],[19.00652,43.446232],[19.00617,43.446673],[19.005354,43.446717],[19.004654,43.446628],[19.004363,43.44632],[19.003896,43.445967],[19.003546,43.445395],[19.003488,43.444689],[19.004071,43.444028],[19.004363,43.443411],[19.004071,43.442222],[19.003546,43.441737],[19.002555,43.441384],[19.001855,43.440591],[19.00133,43.439666],[19.000747,43.439181],[18.999931,43.43896],[18.999231,43.439049],[18.998473,43.439798],[18.998123,43.440944],[18.997831,43.442089],[18.99789,43.443147],[18.998181,43.443764],[18.998006,43.444557],[18.996957,43.445306],[18.995557,43.445791],[18.994566,43.446144],[18.993924,43.446761],[18.993283,43.447774],[18.9927,43.448171],[18.99165,43.448039],[18.991067,43.447554],[18.990542,43.447025],[18.989842,43.446673],[18.989609,43.4461],[18.989201,43.445703],[18.988734,43.445659],[18.98821,43.446011],[18.98821,43.446849],[18.988326,43.447862],[18.98786,43.44892],[18.986868,43.449845],[18.986285,43.450418],[18.985935,43.451102],[18.986344,43.451432],[18.98681,43.4513],[18.987452,43.451432],[18.987918,43.451784],[18.987743,43.452269],[18.987277,43.452534],[18.986519,43.452578],[18.985469,43.452401],[18.984536,43.452181],[18.983544,43.452093],[18.982903,43.452401],[18.982378,43.453503],[18.981912,43.4539],[18.981212,43.4539],[18.980687,43.453547],[18.980046,43.453371],[18.979462,43.453459],[18.978413,43.454913],[18.978063,43.455574],[18.977538,43.455971],[18.977013,43.455707],[18.976547,43.455134],[18.976255,43.454385],[18.975847,43.453812],[18.975322,43.453371],[18.974214,43.453107],[18.973165,43.452974],[18.97194,43.453062],[18.970774,43.453151],[18.969841,43.453062],[18.969199,43.453107],[18.968499,43.452974],[18.965875,43.452225],[18.964651,43.451652],[18.962843,43.450815],[18.961735,43.451212],[18.960452,43.452181],[18.959402,43.452974],[18.958878,43.453195],[18.957653,43.453062],[18.956837,43.452666],[18.956137,43.452269],[18.955729,43.453107],[18.955554,43.453635],[18.956137,43.454517],[18.955903,43.45531],[18.955903,43.456368],[18.955962,43.457117],[18.956545,43.457602],[18.957595,43.457998],[18.958586,43.458439],[18.959461,43.459232],[18.960044,43.459805],[18.960802,43.460334],[18.960977,43.460951],[18.960452,43.461568],[18.96016,43.462449],[18.960452,43.463727],[18.96051,43.464873],[18.960277,43.465754],[18.960569,43.466856],[18.960744,43.467473],[18.960335,43.46809],[18.960219,43.468795],[18.960744,43.46928],[18.961735,43.469588],[18.961793,43.470073],[18.960627,43.471263],[18.960569,43.4721],[18.959985,43.472805],[18.958878,43.473687],[18.957886,43.474568],[18.95707,43.475405],[18.956487,43.476022],[18.95672,43.47686],[18.95707,43.477477],[18.957128,43.478754],[18.956953,43.47968],[18.957303,43.480694],[18.957944,43.48131],[18.958994,43.482148],[18.959461,43.482897],[18.959286,43.483602],[18.959169,43.484175],[18.959402,43.485012],[18.959286,43.485717],[18.958819,43.486334],[18.958469,43.487172],[18.958469,43.487833],[18.958003,43.48867],[18.95707,43.489595],[18.95637,43.4903],[18.95602,43.491138],[18.955495,43.492107],[18.953921,43.492812],[18.952638,43.493209],[18.951647,43.493341],[18.95083,43.493341],[18.949955,43.493429],[18.949197,43.494046],[18.948498,43.495148],[18.947856,43.495941],[18.947448,43.49647],[18.947156,43.497396],[18.946573,43.49788],[18.94564,43.498233],[18.944707,43.498629],[18.943891,43.499114],[18.942375,43.499335],[18.941267,43.499379],[18.940042,43.499202],[18.938876,43.498806],[18.938351,43.498541],[18.938642,43.494355],[18.939167,43.491182],[18.938934,43.489375],[18.938234,43.486863],[18.93736,43.485277],[18.936427,43.484439],[18.935085,43.483602],[18.933219,43.482809],[18.931411,43.482324],[18.929545,43.481399],[18.927621,43.480561],[18.926688,43.480297],[18.925872,43.480782],[18.925288,43.4825],[18.924589,43.484131],[18.923422,43.486026],[18.918874,43.492636],[18.918582,43.493914],[18.919049,43.495368],[18.91969,43.496338],[18.920915,43.496999],[18.921556,43.497572],[18.921848,43.498497],[18.921673,43.499246],[18.920332,43.499467],[18.918874,43.499379],[18.918291,43.499555],[18.917941,43.499863],[18.917024,43.501085],[18.915796,43.502322],[18.915387,43.503117],[18.915387,43.503957],[18.916088,43.504885],[18.917608,43.50621],[18.920064,43.507889],[18.921292,43.509038],[18.921935,43.510452],[18.922285,43.511777],[18.922987,43.512396],[18.924156,43.51297],[18.925735,43.513677],[18.92708,43.514295],[18.928132,43.514516],[18.93047,43.514649],[18.934972,43.514737],[18.938363,43.514826],[18.939533,43.516239],[18.94076,43.517697],[18.94152,43.518183],[18.942456,43.518404],[18.9438,43.518449],[18.945262,43.518095],[18.946548,43.517874],[18.948361,43.518139],[18.950524,43.518714],[18.951752,43.519332],[18.95333,43.519597],[18.953915,43.520172],[18.954733,43.52132],[18.955669,43.522204],[18.95678,43.522778],[18.957774,43.523088],[18.959411,43.52322],[18.961515,43.523309],[18.963035,43.523397],[18.964555,43.523795],[18.966251,43.524722],[18.967362,43.525253],[18.96935,43.525518],[18.971688,43.526136],[18.974787,43.526755],[18.978412,43.527373],[18.97999,43.527771],[18.980867,43.528301],[18.981276,43.529494],[18.981569,43.531792],[18.981627,43.533647],[18.981276,43.536387],[18.980926,43.539126],[18.980575,43.541998],[18.98075,43.542837],[18.981276,43.543544],[18.982095,43.544251],[18.983557,43.544914],[18.984667,43.545577],[18.985194,43.546151],[18.985837,43.54783],[18.987591,43.549862],[18.988701,43.551895],[18.989754,43.553485],[18.990923,43.555694],[18.991332,43.556976],[18.992385,43.557197],[18.99677,43.557152],[18.997997,43.557462],[18.999517,43.558389],[19.000687,43.558699],[19.001739,43.558699],[19.002675,43.558301],[19.003084,43.558169],[19.003785,43.558434],[19.004253,43.558257],[19.004955,43.558655],[19.00589,43.558478],[19.006767,43.558743],[19.008579,43.558345],[19.0101,43.557594],[19.010918,43.556976],[19.011503,43.556224],[19.012087,43.554413],[19.01273,43.552999],[19.013023,43.551895],[19.013958,43.550525],[19.014426,43.549685],[19.015244,43.546769],[19.015829,43.545311],[19.016823,43.545621],[19.017525,43.545577],[19.018168,43.545488],[19.019279,43.54593],[19.020155,43.546814],[19.021266,43.547697],[19.022669,43.548095],[19.024014,43.548095],[19.025534,43.547255],[19.02682,43.545753],[19.027931,43.544251],[19.02875,43.542572],[19.028867,43.541202],[19.029393,43.539965],[19.030504,43.539038],[19.032492,43.538242],[19.033836,43.537314],[19.035707,43.53621],[19.03752,43.535194],[19.041671,43.530643],[19.045471,43.527152],[19.04588,43.526004],[19.045178,43.524899],[19.044126,43.523883],[19.043658,43.523088],[19.043249,43.521409],[19.043483,43.519376],[19.043775,43.517918],[19.044535,43.517035],[19.045646,43.516372],[19.046172,43.515356],[19.04664,43.51403],[19.046757,43.511998],[19.046172,43.509391],[19.045646,43.508463],[19.045705,43.506829],[19.045938,43.505503],[19.04664,43.504796],[19.047634,43.504708],[19.048394,43.50515],[19.049154,43.505547],[19.049973,43.505812],[19.050499,43.505591],[19.05085,43.504664],[19.051317,43.503471],[19.052253,43.502675],[19.05348,43.502013],[19.054533,43.501703],[19.055585,43.501969],[19.056696,43.502896],[19.057456,43.503692],[19.058099,43.504178],[19.060028,43.504752],[19.06225,43.505591],[19.063419,43.506254],[19.064413,43.507226],[19.064706,43.508021],[19.064764,43.509435],[19.065173,43.510672],[19.066401,43.5116],[19.067746,43.512528],[19.0695,43.513058],[19.071312,43.5135],[19.073008,43.5135],[19.07406,43.513544],[19.075112,43.514074],[19.076106,43.515002],[19.076925,43.515179],[19.078211,43.515002],[19.07903,43.515135],[19.079907,43.515621],[19.080959,43.516239],[19.082187,43.516505],[19.083824,43.516549],[19.085344,43.516416],[19.086455,43.516549],[19.087916,43.516814],[19.089495,43.517344],[19.091541,43.51973],[19.092535,43.520569],[19.093587,43.521276],[19.094055,43.522381],[19.09423,43.523176],[19.095049,43.523927],[19.096218,43.524413],[19.097855,43.524943],[19.099492,43.525208],[19.101129,43.524811],[19.102123,43.524148],[19.102883,43.523264],[19.104637,43.523176],[19.113056,43.523176],[19.114752,43.522999],[19.116681,43.523088],[19.117967,43.522778],[19.121767,43.521453],[19.122937,43.521232],[19.124223,43.521144],[19.125626,43.521232],[19.127321,43.521585],[19.129192,43.522248],[19.130245,43.523353],[19.130771,43.524855],[19.131706,43.525429],[19.133168,43.526136],[19.13422,43.526799],[19.135799,43.527197],[19.137904,43.52755],[19.139599,43.528301],[19.142522,43.530996],[19.143516,43.531703],[19.145387,43.532631],[19.148837,43.533603],[19.151526,43.534575],[19.153104,43.535149],[19.154157,43.536122],[19.155268,43.536828],[19.156788,43.537094],[19.158834,43.536784],[19.160822,43.536166],[19.164447,43.535768],[19.168188,43.535591],[19.170878,43.535415],[19.173275,43.534487],[19.176198,43.534133],[19.180641,43.534001],[19.183448,43.533912],[19.185611,43.534045],[19.188242,43.534575],[19.190405,43.53484],[19.192977,43.534663],[19.194614,43.534575],[19.197421,43.535105],[19.198765,43.535194],[19.200169,43.535194],[19.202236,43.534788],[19.204459,43.53408],[19.206213,43.533373],[19.207851,43.532489],[19.209547,43.531517],[19.211009,43.530633],[19.211652,43.530456],[19.212939,43.530633],[19.214752,43.530942],[19.215746,43.530854],[19.217894,43.528859],[19.218799,43.527288],[19.219282,43.526644],[19.219894,43.525839],[19.220215,43.525099],[19.220376,43.524069],[19.220344,43.522943],[19.220055,43.521817],[19.219765,43.520851],[19.219508,43.519403],[19.219443,43.518502],[19.219636,43.517408],[19.21999,43.516539],[19.220087,43.51612],[19.220119,43.515638],[19.22028,43.515251],[19.220698,43.514769],[19.221374,43.514254],[19.222114,43.513578],[19.22279,43.513063],[19.223208,43.512677],[19.223498,43.511936],[19.223788,43.511132],[19.223949,43.510392],[19.223981,43.509716],[19.224013,43.508911],[19.224109,43.507978],[19.224721,43.507495],[19.225107,43.506884],[19.225268,43.506272],[19.225268,43.505307],[19.224978,43.504374],[19.224689,43.503601],[19.224657,43.503086],[19.225077,43.502441],[19.225634,43.501765],[19.226669,43.500252],[19.22642,43.499447],[19.226634,43.498376],[19.226629,43.496709],[19.226277,43.495592],[19.225635,43.494521],[19.22485,43.493165],[19.224492,43.491809],[19.224278,43.490738],[19.224278,43.490167],[19.22485,43.489096],[19.225563,43.487883],[19.22592,43.486955],[19.226206,43.485812],[19.225492,43.484813],[19.224635,43.483385],[19.224064,43.482029],[19.223565,43.480958],[19.223565,43.480102],[19.223779,43.479388],[19.224707,43.478817],[19.226991,43.477817],[19.229989,43.476747],[19.234129,43.475176],[19.238484,43.473106],[19.24191,43.471464],[19.245194,43.46918],[19.247621,43.468109],[19.250119,43.466539],[19.251833,43.465111],[19.253189,43.463826],[19.254117,43.462613],[19.254617,43.461756],[19.255116,43.461256],[19.258043,43.460543],[19.25997,43.460043],[19.263825,43.459115],[19.266038,43.458829],[19.267822,43.458615],[19.268965,43.45833],[19.271035,43.457116],[19.272962,43.455831],[19.275318,43.454475],[19.277317,43.453119],[19.278816,43.451548],[19.279672,43.450834],[19.281171,43.449621],[19.284384,43.447765],[19.286954,43.446623],[19.28988,43.445552],[19.292521,43.444767],[19.295912,43.444291],[19.298477,43.444004],[19.300588,43.443482],[19.304228,43.441769],[19.307693,43.440557],[19.309784,43.440054],[19.311795,43.439841],[19.31485,43.440252],[19.318077,43.440912],[19.320718,43.441555],[19.322571,43.441733],[19.323954,43.441515],[19.325603,43.440611],[19.326786,43.439913],[19.328213,43.439127],[19.331067,43.438187],[19.334067,43.436486],[19.33578,43.433916],[19.337922,43.430419],[19.34092,43.426421],[19.342704,43.424208],[19.344489,43.423066],[19.345917,43.422709],[19.34763,43.422495],[19.349343,43.422209],[19.350699,43.421853],[19.351698,43.420996],[19.352698,43.419854],[19.35384,43.41864],[19.35541,43.416927],[19.356767,43.414928],[19.357623,43.413643],[19.35898,43.412287],[19.359857,43.411689],[19.361377,43.411401],[19.363049,43.411787],[19.364762,43.412573],[19.366118,43.413858],[19.366475,43.414928],[19.366975,43.415428],[19.368117,43.415428],[19.370972,43.415428],[19.374399,43.415428],[19.37704,43.415285],[19.379039,43.415142],[19.380548,43.414927],[19.381394,43.414357],[19.381894,43.413572],[19.382394,43.412644],[19.383036,43.411859],[19.384821,43.410645],[19.385749,43.410003],[19.386677,43.409503],[19.388033,43.408361],[19.390032,43.40622],[19.391816,43.404364],[19.393101,43.40315],[19.394101,43.402365],[19.395528,43.401936],[19.396742,43.401794],[19.397813,43.40158],[19.398241,43.400437],[19.398812,43.399295],[19.399312,43.398724],[19.402096,43.397439],[19.404808,43.396368],[19.408806,43.395298],[19.411947,43.394798],[19.41623,43.394013],[19.420156,43.393442],[19.425581,43.393013],[19.429864,43.392514],[19.433219,43.391943],[19.437288,43.391157],[19.439786,43.390444],[19.442142,43.389087],[19.443855,43.388302],[19.445283,43.387802],[19.446354,43.387089],[19.447496,43.385732],[19.448281,43.384376],[19.448923,43.382806],[19.449494,43.381449],[19.449923,43.38045],[19.450208,43.379236],[19.450351,43.37838],[19.450351,43.377024],[19.450351,43.375524],[19.450208,43.373312],[19.450137,43.369742],[19.450066,43.3686],[19.450208,43.367672],[19.450779,43.367173],[19.452207,43.366887],[19.45392,43.36653],[19.455348,43.365959],[19.456847,43.365317],[19.45806,43.364389],[19.458631,43.363603],[19.458989,43.36239],[19.459131,43.361033],[19.458774,43.359749],[19.458203,43.35775],[19.45649,43.352753],[19.456561,43.351825],[19.457632,43.350611],[19.460059,43.348541],[19.461344,43.347399],[19.462629,43.346471],[19.463914,43.345615],[19.465556,43.345186],[19.467126,43.344544],[19.468625,43.343973],[19.470196,43.343045],[19.47198,43.342045],[19.473693,43.341117],[19.475264,43.339975],[19.47662,43.33869],[19.477548,43.337548],[19.478272,43.336506],[19.478976,43.335335],[19.479547,43.333479],[19.480332,43.33198],[19.481546,43.330767],[19.483402,43.329268],[19.485329,43.328268],[19.487399,43.327626],[19.490255,43.326983],[19.491968,43.326769],[19.494252,43.326769],[19.496465,43.326484],[19.498678,43.32577],[19.499959,43.325459],[19.501034,43.325199],[19.502818,43.324485],[19.504389,43.323628],[19.505959,43.3232],[19.507744,43.322915],[19.509243,43.322343],[19.510599,43.321772],[19.511812,43.321273],[19.512741,43.320416],[19.51374,43.319631],[19.514811,43.318846],[19.515882,43.31856],[19.517095,43.318417],[19.518451,43.318846],[19.519308,43.318988],[19.520307,43.318703],[19.521378,43.318346],[19.522734,43.317775],[19.524233,43.317632],[19.526089,43.317561],[19.527374,43.317489],[19.528159,43.317204],[19.528741,43.316498],[19.529016,43.315491],[19.529516,43.314777],[19.530515,43.314134],[19.532442,43.313278],[19.534155,43.31235],[19.535726,43.310779],[19.53694,43.309209],[19.538082,43.307424],[19.538796,43.30564],[19.539055,43.304259],[19.539081,43.303427],[19.53694,43.302213],[19.534013,43.300072],[19.532799,43.299501],[19.5313,43.299001],[19.530515,43.29843],[19.529873,43.297573],[19.529373,43.296574],[19.529444,43.295575],[19.529873,43.294575],[19.530586,43.293576],[19.530789,43.29293],[19.531015,43.291863],[19.530729,43.290935],[19.529944,43.290007],[19.528944,43.288864],[19.528088,43.287865],[19.526798,43.286234],[19.526038,43.284582],[19.525375,43.282797],[19.525375,43.281512],[19.52666,43.280298],[19.52873,43.278585],[19.529873,43.277229],[19.530444,43.276015],[19.530658,43.272946],[19.532014,43.272375],[19.533156,43.271661],[19.53437,43.270019],[19.535655,43.268163],[19.536511,43.266878],[19.538225,43.265022],[19.540295,43.262595],[19.541865,43.26131],[19.542436,43.259597],[19.543721,43.255314],[19.544578,43.253101],[19.544954,43.250069],[19.544595,43.248122],[19.547362,43.24723],[19.549682,43.24607],[19.55102,43.245535],[19.552805,43.245088],[19.554411,43.245267],[19.556641,43.245713],[19.559497,43.246338],[19.561638,43.246516],[19.563601,43.247319],[19.565297,43.248033],[19.566725,43.24839],[19.567974,43.248211],[19.569312,43.248122],[19.57074,43.247676],[19.572346,43.246962],[19.574934,43.246248],[19.576808,43.245891],[19.578771,43.245535],[19.580287,43.245445],[19.581715,43.245535],[19.583321,43.244821],[19.585373,43.24375],[19.587604,43.242501],[19.590638,43.240091],[19.593494,43.237861],[19.595457,43.23563],[19.597509,43.234024],[19.600186,43.232685],[19.602773,43.231615],[19.605629,43.231258],[19.609287,43.230722],[19.613213,43.230009],[19.618121,43.229205],[19.619638,43.228938],[19.621244,43.228313],[19.622761,43.226975],[19.625081,43.224922],[19.627044,43.223138],[19.628025,43.221889],[19.629275,43.219747],[19.629631,43.217695],[19.630256,43.215643],[19.63097,43.214393],[19.632398,43.212698],[19.635164,43.20904],[19.636591,43.206452],[19.636996,43.205366],[19.637394,43.203507],[19.63711,43.202071],[19.636502,43.200473],[19.635875,43.198121],[19.636324,43.196637],[19.637216,43.195655],[19.638465,43.194674],[19.639959,43.192707],[19.640607,43.191283],[19.64141,43.189944],[19.642124,43.189498],[19.646228,43.188427],[19.650154,43.187624],[19.652831,43.18691],[19.659167,43.186286],[19.662736,43.185929],[19.664342,43.18584],[19.666484,43.185661],[19.668893,43.185215],[19.671302,43.184323],[19.6738,43.183431],[19.67612,43.182449],[19.67853,43.181111],[19.679779,43.18004],[19.680403,43.179326],[19.68076,43.178077],[19.680582,43.177095],[19.6796,43.175489],[19.679868,43.174597],[19.680135,43.172991],[19.680493,43.172634],[19.681742,43.172009],[19.683437,43.171117],[19.685311,43.170225],[19.687542,43.168797],[19.688345,43.169154],[19.689505,43.169332],[19.690754,43.1696],[19.692003,43.169511],[19.693431,43.169154],[19.696197,43.169422],[19.699052,43.169957],[19.700569,43.170314],[19.7028,43.170581],[19.705834,43.170671],[19.709849,43.170938],[19.713775,43.171028],[19.716095,43.171117],[19.718683,43.171206],[19.720378,43.171206],[19.722163,43.171563],[19.724126,43.171741],[19.726446,43.171831],[19.72823,43.171831],[19.729123,43.171028],[19.731978,43.168797],[19.734655,43.166388],[19.736618,43.164246],[19.738938,43.161658],[19.740187,43.159874],[19.741169,43.158892],[19.74215,43.159428],[19.743043,43.159695],[19.74456,43.159606],[19.746344,43.159428],[19.749199,43.159339],[19.751966,43.15916],[19.753572,43.159071],[19.754553,43.159517],[19.755535,43.160142],[19.756248,43.161569],[19.758033,43.16264],[19.760442,43.163711],[19.762316,43.164157],[19.76535,43.164871],[19.767313,43.165495],[19.770347,43.166298],[19.770704,43.164425],[19.771418,43.163086],[19.771974,43.16183],[19.772838,43.160784],[19.774221,43.160175],[19.776181,43.159652],[19.777218,43.158868],[19.778485,43.158084],[19.779235,43.156995],[19.779292,43.1546],[19.779868,43.15386],[19.780041,43.153032],[19.780341,43.151665],[19.779805,43.150148],[19.779805,43.14872],[19.779538,43.147471],[19.779062,43.146151],[19.779805,43.144972],[19.780519,43.144169],[19.780876,43.143009],[19.780519,43.141671],[19.779347,43.140385],[19.778946,43.139923],[19.77837,43.139662],[19.777485,43.13944],[19.777039,43.138548],[19.776861,43.137477],[19.776682,43.136585],[19.777753,43.136406],[19.779359,43.13596],[19.781233,43.13489],[19.782571,43.133908],[19.784088,43.133016],[19.784624,43.132302],[19.784891,43.131142],[19.784802,43.129893],[19.785338,43.128733],[19.787836,43.125163],[19.789531,43.12329],[19.790959,43.122397],[19.792565,43.12204],[19.794439,43.12204],[19.795866,43.122219],[19.797294,43.122219],[19.798722,43.121773],[19.799347,43.121505],[19.800774,43.120077],[19.802737,43.117044],[19.804433,43.115081],[19.805682,43.113831],[19.80702,43.11285],[19.80827,43.112136],[19.809697,43.112136],[19.811393,43.11285],[19.81282,43.113207],[19.814783,43.113921],[19.818174,43.115259],[19.821565,43.116508],[19.823439,43.117222],[19.825134,43.117847],[19.827186,43.118114],[19.82906,43.117847],[19.830488,43.11749],[19.832081,43.116546],[19.833789,43.114991],[19.834949,43.113742],[19.83602,43.112225],[19.83602,43.110351],[19.835026,43.109007],[19.833696,43.1075],[19.831891,43.106136],[19.829895,43.1047],[19.831202,43.102767],[19.832366,43.100536],[19.833221,43.099459],[19.834076,43.09831],[19.834235,43.095985],[19.834414,43.093665],[19.834503,43.092505],[19.834592,43.091702],[19.837448,43.090988],[19.838429,43.090899],[19.839321,43.092684],[19.840419,43.094332],[19.841552,43.095271],[19.844319,43.097592],[19.846371,43.098841],[19.848155,43.099733],[19.855074,43.101756],[19.85916,43.103192],[19.861155,43.104054],[19.860201,43.107674],[19.86201,43.107787],[19.863503,43.107764],[19.865823,43.107764],[19.867251,43.107318],[19.86841,43.106871],[19.871623,43.106425],[19.874656,43.105711],[19.876441,43.105176],[19.877958,43.104462],[19.879832,43.103124],[19.88126,43.101785],[19.883133,43.101607],[19.884918,43.10125],[19.886346,43.100536],[19.887506,43.099644],[19.888487,43.098305],[19.88929,43.097324],[19.891085,43.09752],[19.8917,43.097859],[19.892413,43.098216],[19.893395,43.098573],[19.894644,43.098573],[19.895551,43.098669],[19.897451,43.098813],[19.899462,43.098841],[19.900801,43.099019],[19.90205,43.098751],[19.902586,43.098038],[19.903299,43.096967],[19.903746,43.096253],[19.904281,43.095361],[19.905173,43.094022],[19.905976,43.092952],[19.906667,43.091346],[19.907143,43.090843],[19.909278,43.089382],[19.911062,43.088222],[19.913739,43.086616],[19.915256,43.085545],[19.916148,43.085278],[19.917119,43.085674],[19.919361,43.087241],[19.92061,43.088133],[19.922484,43.088401],[19.924625,43.088579],[19.926499,43.089739],[19.929354,43.089828],[19.932745,43.089828],[19.935511,43.090364],[19.938099,43.091792],[19.940597,43.093665],[19.94265,43.095271],[19.944256,43.096788],[19.946384,43.098023],[19.949424,43.09953],[19.95218,43.100966],[19.953415,43.101756],[19.954785,43.103302],[19.955677,43.104551],[19.957015,43.106782],[19.957976,43.1075],[19.959692,43.108567],[19.961209,43.10937],[19.963391,43.110156],[19.965046,43.110619],[19.966652,43.110797],[19.968237,43.110515],[19.969062,43.109816],[19.969865,43.108745],[19.971114,43.107585],[19.972363,43.106514],[19.973938,43.104915],[19.974983,43.103695],[19.975397,43.102678],[19.97504,43.101607],[19.974148,43.100536],[19.973255,43.098484],[19.97272,43.09661],[19.972631,43.095182],[19.972988,43.093665],[19.973969,43.090453],[19.975129,43.087687],[19.975575,43.086259],[19.9762,43.084921],[19.977449,43.084207],[19.979145,43.083493],[19.98084,43.082512],[19.982584,43.081438],[19.983606,43.08037],[19.984105,43.079213],[19.984485,43.078207],[19.9842,43.077059],[19.98344,43.075982],[19.982535,43.075284],[19.981554,43.074302],[19.981197,43.073143],[19.981464,43.071536],[19.982089,43.069484],[19.983249,43.067075],[19.984231,43.065647],[19.986005,43.065213],[19.9878,43.063952],[19.988692,43.063149],[19.988692,43.062346],[19.988157,43.06065],[19.988068,43.059044],[19.988285,43.057961],[19.989425,43.056238],[19.991421,43.054515],[19.992656,43.053438],[19.994461,43.052218],[19.995982,43.051572],[19.998547,43.050136],[20.000542,43.048628],[20.001631,43.048158],[20.003108,43.047407],[20.005008,43.047407],[20.006199,43.04669],[20.006855,43.046653],[20.007652,43.046383],[20.00816,43.045903],[20.008816,43.045633],[20.009687,43.04547],[20.010288,43.045123],[20.010549,43.044681],[20.010819,43.04434],[20.011074,43.043749],[20.011445,43.043286],[20.011875,43.042858],[20.012202,43.042543],[20.012646,43.042297],[20.013059,43.041788],[20.013887,43.041605],[20.014392,43.041227],[20.014996,43.041013],[20.015655,43.040696],[20.016422,43.040789],[20.017308,43.040779],[20.017919,43.040422],[20.018691,43.04033],[20.019366,43.040266],[20.019821,43.040304],[20.020278,43.04035],[20.02087,43.040371],[20.021469,43.040249],[20.022012,43.039984],[20.022717,43.039531],[20.023443,43.03911],[20.023917,43.038886],[20.024513,43.038807],[20.025199,43.038792],[20.026015,43.038611],[20.026833,43.038438],[20.027651,43.038324],[20.028481,43.038325],[20.029207,43.038197],[20.02966,43.038109],[20.030241,43.03773],[20.031171,43.036958],[20.032151,43.036244],[20.033105,43.035523],[20.03359,43.035816],[20.034108,43.036022],[20.034938,43.035907],[20.03569,43.035901],[20.03611,43.035717],[20.036534,43.035147],[20.036813,43.034729],[20.037339,43.03439],[20.037691,43.033662],[20.037984,43.033309],[20.038582,43.032945],[20.039344,43.032519],[20.040013,43.032247],[20.040357,43.031838],[20.040764,43.03148],[20.041346,43.031218],[20.041465,43.030768],[20.041756,43.03029],[20.04173,43.029436],[20.042172,43.029036],[20.04281,43.028859],[20.04364,43.028568],[20.044494,43.028617],[20.045107,43.028326],[20.045571,43.027994],[20.045829,43.027478],[20.046321,43.02716],[20.046751,43.026967],[20.047489,43.026485],[20.047798,43.025679],[20.047835,43.02503],[20.048085,43.024657],[20.048571,43.024482],[20.049254,43.024275],[20.04933,43.023454],[20.049513,43.022947],[20.049637,43.022405],[20.049661,43.021875],[20.049859,43.021374],[20.050732,43.021162],[20.051653,43.020876],[20.052426,43.020265],[20.053412,43.019637],[20.054731,43.018601],[20.05517,43.018331],[20.055734,43.018046],[20.056198,43.017539],[20.055966,43.016713],[20.055618,43.015818],[20.055057,43.014889],[20.054415,43.013877],[20.054196,43.01264],[20.054109,43.011713],[20.054142,43.01099],[20.05403,43.010593],[20.054035,43.009622],[20.054525,43.009237],[20.055348,43.008854],[20.055964,43.008572],[20.056669,43.008295],[20.057069,43.008021],[20.056973,43.007522],[20.05719,43.00717],[20.057936,43.006437],[20.058551,43.006037],[20.058876,43.005597],[20.059216,43.005221],[20.059992,43.005527],[20.060921,43.006014],[20.061451,43.006101],[20.062097,43.006485],[20.062931,43.006385],[20.064079,43.006206],[20.065074,43.005853],[20.06565,43.005505],[20.065549,43.004868],[20.065599,43.004159],[20.065851,43.00356],[20.066112,43.002914],[20.065857,43.002245],[20.06596,43.001723],[20.065836,43.001269],[20.066111,43.000952],[20.066408,43.000556],[20.066836,43.000237],[20.067279,42.999925],[20.067574,42.999405],[20.068146,42.999044],[20.068831,42.998903],[20.069405,42.999136],[20.069843,42.999385],[20.070394,42.999571],[20.070982,42.999693],[20.071656,42.999797],[20.072426,42.999813],[20.07299,42.999997],[20.073622,42.999704],[20.074479,42.999217],[20.075466,42.999058],[20.076295,42.999051],[20.077015,42.998664],[20.077671,42.998393],[20.078115,42.997855],[20.07839,42.997244],[20.079054,42.996366],[20.078951,42.995769],[20.078854,42.995319],[20.079213,42.994916],[20.079457,42.994509],[20.079808,42.993947],[20.080442,42.993755],[20.081122,42.993658],[20.081836,42.993658],[20.082689,42.993532],[20.083162,42.993829],[20.083625,42.993967],[20.084028,42.994297],[20.084355,42.994628],[20.084841,42.994697],[20.085497,42.994955],[20.085926,42.995173],[20.086725,42.995297],[20.08719,42.994881],[20.087723,42.994457],[20.087905,42.993941],[20.087788,42.993459],[20.087245,42.992894],[20.0871,42.992399],[20.087401,42.992078],[20.087839,42.991925],[20.088607,42.991583],[20.089407,42.991329],[20.089956,42.991273],[20.090127,42.990648],[20.09014,42.990059],[20.089858,42.989404],[20.090106,42.989014],[20.091284,42.98874],[20.092313,42.988543],[20.092871,42.98841],[20.093567,42.988446],[20.09437,42.988267],[20.09496,42.987929],[20.095444,42.987511],[20.0961,42.987123],[20.096598,42.986594],[20.096858,42.986202],[20.097274,42.985708],[20.097866,42.985202],[20.098632,42.98491],[20.098787,42.984506],[20.099139,42.984128],[20.099898,42.983745],[20.099906,42.982779],[20.09967,42.982278],[20.099586,42.981708],[20.099826,42.981227],[20.100209,42.980812],[20.100675,42.98043],[20.101344,42.97999],[20.101621,42.979437],[20.101693,42.978648],[20.102148,42.977922],[20.10276,42.976566],[20.102715,42.975648],[20.102826,42.97498],[20.103175,42.97441],[20.103593,42.973865],[20.104555,42.973181],[20.105661,42.97216],[20.106342,42.971652],[20.107092,42.97158],[20.107896,42.97141],[20.108545,42.971342],[20.109089,42.971378],[20.11014,42.971582],[20.110995,42.971552],[20.111333,42.970963],[20.111188,42.970409],[20.111691,42.969904],[20.112031,42.969646],[20.112502,42.969465],[20.112953,42.969428],[20.113449,42.969185],[20.113953,42.968983],[20.114221,42.968418],[20.114743,42.967975],[20.115207,42.967819],[20.11595,42.967597],[20.116654,42.967254],[20.117221,42.966515],[20.117444,42.966011],[20.117347,42.96556],[20.117778,42.965316],[20.118303,42.965381],[20.11885,42.965492],[20.119319,42.965361],[20.119657,42.965095],[20.119943,42.964591],[20.120771,42.964586],[20.12113,42.964241],[20.121539,42.96374],[20.121948,42.964128],[20.122285,42.964567],[20.122673,42.965008],[20.122879,42.965428],[20.123285,42.965657],[20.123801,42.965681],[20.124161,42.966108],[20.124751,42.966627],[20.125547,42.967095],[20.126729,42.9674],[20.127604,42.9677],[20.128179,42.968001],[20.128767,42.968301],[20.129925,42.968526],[20.130582,42.968792],[20.131071,42.969289],[20.1313,42.969639],[20.131927,42.970061],[20.132723,42.970026],[20.133393,42.969879],[20.133808,42.970149],[20.133893,42.97066],[20.133768,42.971086],[20.133817,42.971785],[20.134044,42.972774],[20.134372,42.973172],[20.134995,42.973577],[20.135707,42.973862],[20.136309,42.974169],[20.136474,42.974578],[20.136644,42.975187],[20.136705,42.975885],[20.136554,42.976306],[20.137093,42.977267],[20.137126,42.978069],[20.137567,42.978696],[20.137444,42.97919],[20.137372,42.97992],[20.138173,42.980438],[20.138704,42.980829],[20.139341,42.981299],[20.140128,42.981635],[20.140887,42.982259],[20.141134,42.98275],[20.141281,42.983194],[20.142012,42.983629],[20.142543,42.984019],[20.143056,42.984739],[20.143682,42.98522],[20.144557,42.986082],[20.14524,42.986765],[20.146055,42.987466],[20.146576,42.988404],[20.147034,42.989047],[20.147599,42.989181],[20.148164,42.988964],[20.149214,42.988806],[20.149678,42.988886],[20.15025,42.988466],[20.150972,42.987793],[20.151273,42.986943],[20.151804,42.985739],[20.152329,42.984569],[20.151964,42.983823],[20.151592,42.983162],[20.151717,42.98203],[20.151894,42.981195],[20.15202,42.979888],[20.152354,42.979193],[20.152746,42.97835],[20.152797,42.977639],[20.152848,42.976457],[20.153235,42.974766],[20.153523,42.973914],[20.15406,42.973863],[20.155046,42.973881],[20.15589,42.973773],[20.156562,42.973576],[20.157548,42.9733],[20.158396,42.972974],[20.159061,42.972568],[20.159541,42.972016],[20.160358,42.971844],[20.160972,42.971495],[20.161629,42.97135],[20.162485,42.97124],[20.163082,42.971405],[20.163816,42.971377],[20.164408,42.971047],[20.165195,42.970736],[20.166116,42.970451],[20.166857,42.970456],[20.167389,42.970385],[20.167675,42.970704],[20.167637,42.971296],[20.167859,42.97179],[20.16864,42.972277],[20.169571,42.97257],[20.170327,42.972531],[20.171054,42.972412],[20.171721,42.972132],[20.172355,42.971822],[20.172657,42.971682],[20.173275,42.971408],[20.173798,42.971235],[20.17454,42.970984],[20.175724,42.970791],[20.176537,42.970684],[20.177439,42.970101],[20.178048,42.969425],[20.178785,42.968742],[20.17911,42.968203],[20.17935,42.967809],[20.179601,42.967406],[20.180229,42.966227],[20.180641,42.965847],[20.182549,42.965023],[20.183448,42.964601],[20.184253,42.964283],[20.184831,42.963883],[20.185812,42.963595],[20.186487,42.963047],[20.186743,42.962669],[20.186467,42.961887],[20.186416,42.9613],[20.186408,42.960792],[20.186608,42.960394],[20.187367,42.960048],[20.187981,42.959457],[20.18833,42.959025],[20.188822,42.958651],[20.189591,42.958466],[20.190181,42.958361],[20.190699,42.958281],[20.191181,42.958215],[20.191673,42.958139],[20.192153,42.958004],[20.192914,42.957786],[20.193646,42.957672],[20.194368,42.957628],[20.195043,42.957673],[20.195691,42.957825],[20.196583,42.957904],[20.197702,42.957888],[20.198586,42.957748],[20.199345,42.95752],[20.200215,42.957085],[20.200982,42.956713],[20.20205,42.956525],[20.203106,42.956457],[20.20376,42.956522],[20.204563,42.956969],[20.20514,42.957094],[20.205699,42.957146],[20.206275,42.957212],[20.206819,42.957486],[20.207655,42.957784],[20.208124,42.957957],[20.208892,42.95783],[20.20967,42.957864],[20.210424,42.95785],[20.211275,42.957798],[20.211909,42.957416],[20.212713,42.95698],[20.213288,42.956563],[20.213909,42.956183],[20.214763,42.955732],[20.215536,42.955393],[20.216336,42.95517],[20.21677,42.954888],[20.21713,42.954268],[20.217433,42.95351],[20.217758,42.952911],[20.217814,42.952455],[20.217806,42.952006],[20.21819,42.951345],[20.218627,42.950754],[20.218996,42.950412],[20.219296,42.950054],[20.219975,42.949582],[20.220625,42.949156],[20.220996,42.948823],[20.22129,42.948499],[20.221928,42.948193],[20.222458,42.947815],[20.222829,42.947541],[20.22349,42.946987],[20.223962,42.946582],[20.224364,42.946093],[20.224798,42.945811],[20.225423,42.945685],[20.225804,42.945461],[20.226155,42.945037],[20.226694,42.944522],[20.226978,42.944208],[20.227132,42.943664],[20.227495,42.943238],[20.227896,42.942927],[20.228474,42.942823],[20.229114,42.942823],[20.229599,42.942832],[20.230573,42.942868],[20.231462,42.942812],[20.231994,42.94262],[20.232521,42.942285],[20.232915,42.942],[20.233375,42.941775],[20.233911,42.94166],[20.234452,42.941451],[20.23515,42.941358],[20.23584,42.941233],[20.236792,42.941169],[20.237832,42.941027],[20.238461,42.940798],[20.238899,42.94049],[20.239912,42.940185],[20.240685,42.940012],[20.24133,42.940123],[20.241867,42.940204],[20.242949,42.940193],[20.244272,42.940078],[20.245564,42.939698],[20.246401,42.93951],[20.247369,42.939921],[20.248128,42.940156],[20.249051,42.940437],[20.250363,42.940569],[20.251671,42.94042],[20.252236,42.940099],[20.252754,42.939535],[20.253561,42.938978],[20.254534,42.938607],[20.255307,42.938434],[20.255953,42.938329],[20.25666,42.937842],[20.257239,42.937226],[20.258073,42.937029],[20.259042,42.936923],[20.260004,42.936611],[20.260459,42.936147],[20.260978,42.935394],[20.262092,42.935046],[20.262842,42.935067],[20.264188,42.93506],[20.264923,42.934802],[20.265568,42.934255],[20.266651,42.933698],[20.267859,42.93299],[20.269277,42.932326],[20.270104,42.93247],[20.270509,42.932741],[20.271061,42.93294],[20.271486,42.93268],[20.271887,42.932397],[20.272582,42.932703],[20.273329,42.933073],[20.274563,42.933383],[20.275279,42.9336],[20.275846,42.933532],[20.276485,42.934011],[20.277277,42.934511],[20.277942,42.934203],[20.278179,42.933649],[20.278384,42.932971],[20.278809,42.932193],[20.280374,42.932332],[20.281265,42.932348],[20.282003,42.932314],[20.282402,42.932079],[20.282866,42.931857],[20.283458,42.931516],[20.283733,42.930561],[20.28399,42.928987],[20.284926,42.927314],[20.28551,42.927462],[20.285967,42.92758],[20.286431,42.927658],[20.286898,42.927661],[20.28748,42.927571],[20.288038,42.927345],[20.288744,42.927019],[20.289161,42.926798],[20.289582,42.926558],[20.290027,42.926293],[20.290527,42.926043],[20.291075,42.92582],[20.291783,42.925554],[20.292157,42.924906],[20.292318,42.924455],[20.293039,42.923617],[20.29379,42.92312],[20.294538,42.922755],[20.295072,42.922611],[20.29585,42.922573],[20.296583,42.922405],[20.297143,42.922348],[20.297556,42.922391],[20.298219,42.922169],[20.29869,42.921889],[20.299234,42.921339],[20.300373,42.921023],[20.301277,42.921203],[20.302344,42.921091],[20.30337,42.921129],[20.303744,42.920816],[20.304355,42.920746],[20.304626,42.921094],[20.305194,42.921334],[20.305993,42.921314],[20.306653,42.921139],[20.307179,42.921239],[20.307615,42.921763],[20.307936,42.922062],[20.308507,42.922254],[20.309496,42.922695],[20.309881,42.922978],[20.310098,42.923338],[20.311268,42.92338],[20.311678,42.922796],[20.312118,42.922308],[20.312026,42.921609],[20.311367,42.921297],[20.310741,42.921033],[20.310904,42.920564],[20.310704,42.920162],[20.310448,42.919549],[20.310357,42.918662],[20.310029,42.917804],[20.310529,42.917564],[20.311431,42.917426],[20.314948,42.917184],[20.316974,42.916574],[20.318916,42.915936],[20.320518,42.91596],[20.322351,42.915967],[20.322753,42.915366],[20.323444,42.9148],[20.324112,42.914184],[20.324733,42.913485],[20.325312,42.91288],[20.325894,42.912255],[20.326749,42.912418],[20.327525,42.912862],[20.328369,42.913243],[20.328724,42.913702],[20.329509,42.913759],[20.330996,42.913492],[20.331754,42.913107],[20.332253,42.912455],[20.333117,42.911633],[20.333631,42.911015],[20.334085,42.910262],[20.334405,42.90969],[20.334761,42.909363],[20.335026,42.909019],[20.335575,42.908347],[20.336337,42.907675],[20.337023,42.907883],[20.337515,42.908084],[20.338062,42.90833],[20.338617,42.908404],[20.33902,42.908646],[20.339488,42.909172],[20.340085,42.909396],[20.341019,42.909577],[20.341809,42.909671],[20.342621,42.909601],[20.343173,42.909667],[20.34405,42.909881],[20.344398,42.910295],[20.344746,42.910765],[20.345016,42.911328],[20.345583,42.911213],[20.345851,42.910738],[20.346026,42.910162],[20.346044,42.909578],[20.346222,42.909143],[20.346438,42.908563],[20.345934,42.908078],[20.345826,42.907505],[20.345779,42.906963],[20.346077,42.90664],[20.346535,42.906466],[20.347333,42.906362],[20.3477,42.90614],[20.347328,42.905699],[20.346713,42.905324],[20.346987,42.904703],[20.347092,42.904154],[20.34759,42.903746],[20.348013,42.903328],[20.347736,42.902532],[20.347806,42.901579],[20.347799,42.901047],[20.348284,42.900689],[20.34858,42.900198],[20.34897,42.900059],[20.349357,42.899612],[20.34918,42.898774],[20.349394,42.898339],[20.349399,42.897589],[20.349514,42.897038],[20.34977,42.896593],[20.349901,42.896104],[20.349866,42.895644],[20.349669,42.895138],[20.349175,42.894853],[20.348459,42.894545],[20.347827,42.89416],[20.347584,42.893769],[20.347387,42.893291],[20.347187,42.892833],[20.346835,42.892111],[20.346543,42.891525],[20.346008,42.890491],[20.345443,42.889445],[20.345078,42.888501],[20.344923,42.887714],[20.344973,42.886795],[20.345152,42.885685],[20.345435,42.884729],[20.345674,42.883484],[20.345879,42.882134],[20.346124,42.880738],[20.346269,42.879524],[20.346177,42.878525],[20.346066,42.877512],[20.34594,42.876625],[20.345865,42.876128],[20.34513,42.875467],[20.344562,42.874851],[20.344392,42.874222],[20.343965,42.873276],[20.343293,42.872675],[20.342543,42.871788],[20.342161,42.870835],[20.342137,42.869841],[20.342146,42.869025],[20.342357,42.868157],[20.34303,42.86752],[20.343604,42.866966],[20.344307,42.866324],[20.344411,42.86569],[20.344695,42.865006],[20.344552,42.864339],[20.344497,42.863797],[20.344406,42.863179],[20.344611,42.86229],[20.344878,42.861631],[20.345205,42.860907],[20.345577,42.860463],[20.345976,42.860175],[20.34652,42.859682],[20.347222,42.858978],[20.347623,42.858019],[20.348,42.85731],[20.348277,42.856742],[20.348618,42.855958],[20.348788,42.855165],[20.348867,42.854437],[20.348351,42.8539],[20.347914,42.853539],[20.347554,42.853179],[20.347268,42.852636],[20.347254,42.852019],[20.34738,42.851405],[20.34765,42.850872],[20.347503,42.850275],[20.347501,42.849702],[20.347636,42.849063],[20.347851,42.848607],[20.347975,42.847706],[20.348154,42.847003],[20.348187,42.846334],[20.348534,42.8454],[20.348917,42.844713],[20.349428,42.844271],[20.350149,42.843753],[20.350969,42.843369],[20.351714,42.842767],[20.351764,42.841648],[20.351568,42.840473],[20.351506,42.839963],[20.351723,42.83943],[20.351878,42.838796],[20.351723,42.838226],[20.351583,42.837782],[20.351583,42.837358],[20.351627,42.836927],[20.35182,42.83656],[20.351968,42.836028],[20.352196,42.835365],[20.352465,42.834855],[20.352542,42.834431],[20.352727,42.833894],[20.352911,42.833454],[20.352593,42.833373],[20.352094,42.833291],[20.351468,42.833196],[20.350822,42.833144],[20.35035,42.832962],[20.350047,42.832837],[20.349746,42.832717],[20.349296,42.832627],[20.348941,42.83266],[20.348449,42.832726],[20.347922,42.832801],[20.347395,42.832896],[20.346839,42.832996],[20.346153,42.833085],[20.34539,42.833188],[20.344896,42.833153],[20.344536,42.833148],[20.34419,42.833141],[20.343661,42.833232],[20.343171,42.833506],[20.342607,42.833906],[20.342219,42.834111],[20.341782,42.834272],[20.341437,42.834661],[20.341199,42.83521],[20.340651,42.835665],[20.340122,42.836095],[20.339574,42.836198],[20.339086,42.836146],[20.338691,42.835911],[20.338178,42.835795],[20.337331,42.835779],[20.336619,42.835824],[20.336202,42.835834],[20.335785,42.835846],[20.335232,42.835871],[20.334545,42.835549],[20.33427,42.83528],[20.333812,42.835058],[20.333415,42.834917],[20.333005,42.834746],[20.332476,42.834395],[20.331921,42.834011],[20.331417,42.833676],[20.33107,42.833643],[20.330654,42.833567],[20.330116,42.833473],[20.329514,42.833522],[20.329137,42.833568],[20.328815,42.83359],[20.328331,42.833566],[20.327898,42.833412],[20.327475,42.833144],[20.32715,42.832882],[20.326642,42.83244],[20.326637,42.831832],[20.32671,42.831229],[20.326332,42.830578],[20.325745,42.830056],[20.325345,42.829552],[20.324638,42.829272],[20.323949,42.829127],[20.323208,42.828915],[20.322753,42.828856],[20.322349,42.828698],[20.321799,42.828671],[20.321357,42.82865],[20.321021,42.82862],[20.320525,42.828525],[20.320187,42.828297],[20.319636,42.828116],[20.319214,42.828217],[20.318797,42.828317],[20.318381,42.828417],[20.317825,42.82855],[20.317302,42.828717],[20.316779,42.829047],[20.31657,42.829562],[20.31648,42.830117],[20.316389,42.830673],[20.31631,42.831178],[20.31627,42.831544],[20.316243,42.831913],[20.316263,42.83242],[20.316285,42.832975],[20.316301,42.833392],[20.316297,42.833825],[20.316244,42.834303],[20.31605,42.834795],[20.315831,42.83535],[20.315612,42.835906],[20.315246,42.836041],[20.314829,42.836037],[20.314274,42.836032],[20.313718,42.836026],[20.313301,42.836022],[20.312885,42.836018],[20.31238,42.836021],[20.311874,42.836065],[20.311457,42.836101],[20.310921,42.836023],[20.310417,42.835704],[20.310039,42.835594],[20.309646,42.835533],[20.309171,42.835668],[20.308731,42.835948],[20.308373,42.835819],[20.307975,42.835772],[20.307608,42.835736],[20.307102,42.83572],[20.306425,42.83561],[20.305867,42.835622],[20.305262,42.835728],[20.304693,42.835913],[20.304312,42.835994],[20.303924,42.836077],[20.303397,42.836189],[20.302884,42.836281],[20.302371,42.836302],[20.301816,42.836324],[20.30113,42.836293],[20.300611,42.836263],[20.30009,42.836251],[20.299673,42.836242],[20.299257,42.836233],[20.29884,42.836224],[20.298423,42.836214],[20.298006,42.836205],[20.29801,42.835769],[20.298015,42.835214],[20.29758,42.83456],[20.297238,42.833929],[20.297047,42.833361],[20.296924,42.832944],[20.296751,42.832579],[20.296381,42.832226],[20.295995,42.831856],[20.295526,42.831318],[20.295229,42.830737],[20.295016,42.83032],[20.294804,42.829904],[20.294591,42.829487],[20.294396,42.829105],[20.294202,42.828723],[20.293991,42.828307],[20.293777,42.827735],[20.293771,42.827163],[20.293766,42.826746],[20.293812,42.826214],[20.293859,42.825679],[20.293568,42.825461],[20.293237,42.825342],[20.292686,42.825321],[20.292097,42.825279],[20.291397,42.825465],[20.290887,42.82556],[20.290199,42.825636],[20.289614,42.825659],[20.289149,42.82562],[20.288557,42.825568],[20.288105,42.825562],[20.287767,42.825484],[20.28721,42.825502],[20.286732,42.825638],[20.28633,42.825915],[20.285953,42.826061],[20.285543,42.826049],[20.285183,42.825457],[20.284905,42.824638],[20.284252,42.824414],[20.283663,42.82433],[20.283027,42.824183],[20.282501,42.824009],[20.282008,42.823799],[20.281246,42.82378],[20.280627,42.824177],[20.280202,42.82431],[20.279427,42.824166],[20.278856,42.823923],[20.278169,42.823691],[20.27755,42.82346],[20.277279,42.823126],[20.27731,42.822667],[20.277483,42.822374],[20.277374,42.821919],[20.277053,42.821508],[20.27633,42.821207],[20.275741,42.820893],[20.275483,42.820329],[20.274918,42.820004],[20.274567,42.819811],[20.274108,42.819631],[20.273589,42.819477],[20.273087,42.819309],[20.272495,42.819047],[20.271897,42.818973],[20.271374,42.818755],[20.270868,42.818398],[20.270118,42.817991],[20.269361,42.81796],[20.268884,42.817991],[20.268414,42.817969],[20.267848,42.817883],[20.267397,42.818006],[20.266785,42.818214],[20.266175,42.817925],[20.265755,42.817724],[20.265968,42.817032],[20.265982,42.816403],[20.265202,42.816003],[20.264646,42.815795],[20.264188,42.815682],[20.263526,42.815517],[20.263009,42.815374],[20.262582,42.815245],[20.262191,42.815121],[20.261816,42.814897],[20.261425,42.814623],[20.260862,42.814373],[20.260306,42.814378],[20.259851,42.814515],[20.259512,42.814706],[20.259186,42.814898],[20.258727,42.815219],[20.258043,42.815284],[20.257564,42.815263],[20.257118,42.815051],[20.256633,42.814818],[20.256285,42.814764],[20.255899,42.814698],[20.255514,42.814617],[20.25506,42.81443],[20.254694,42.813916],[20.254265,42.813313],[20.254103,42.812731],[20.253744,42.812295],[20.253387,42.81209],[20.252999,42.811895],[20.252545,42.811684],[20.252274,42.811222],[20.252165,42.81076],[20.252813,42.810498],[20.253251,42.810118],[20.253447,42.809476],[20.253511,42.808882],[20.253819,42.808402],[20.25406,42.808044],[20.254337,42.807644],[20.254894,42.807059],[20.255596,42.806995],[20.255895,42.806731],[20.256019,42.80633],[20.256642,42.806136],[20.257006,42.805944],[20.257437,42.805546],[20.257951,42.805128],[20.258326,42.804819],[20.258683,42.804587],[20.259349,42.804509],[20.259839,42.804307],[20.260248,42.803985],[20.260751,42.803977],[20.261456,42.803963],[20.262106,42.80406],[20.262598,42.80414],[20.26274,42.803761],[20.262696,42.803205],[20.262651,42.80265],[20.262606,42.802094],[20.262558,42.801499],[20.262528,42.801101],[20.262497,42.800684],[20.262456,42.800129],[20.262424,42.799712],[20.262388,42.799268],[20.262344,42.798712],[20.262148,42.798204],[20.261872,42.797823],[20.261776,42.797261],[20.261783,42.796826],[20.261881,42.796357],[20.26205,42.795838],[20.262215,42.795502],[20.262297,42.795069],[20.262427,42.794549],[20.26267,42.794053],[20.262883,42.793632],[20.262934,42.793216],[20.263001,42.79266],[20.263052,42.792243],[20.263103,42.791827],[20.26317,42.791271],[20.263237,42.790716],[20.263309,42.790103],[20.263357,42.789686],[20.263411,42.789292],[20.26335,42.788868],[20.263568,42.788411],[20.263737,42.787946],[20.263845,42.787581],[20.263999,42.787076],[20.264164,42.786532],[20.264329,42.785987],[20.264473,42.785511],[20.264601,42.785095],[20.264805,42.78442],[20.26493,42.784003],[20.265061,42.783571],[20.26523,42.783015],[20.265377,42.782523],[20.265502,42.782107],[20.265626,42.78169],[20.265749,42.781281],[20.265913,42.780732],[20.266079,42.780177],[20.266203,42.77976],[20.266317,42.779414],[20.266216,42.778925],[20.26608,42.778432],[20.265668,42.77789],[20.265282,42.777473],[20.264962,42.777111],[20.264692,42.776749],[20.26425,42.776383],[20.263707,42.775982],[20.263164,42.775744],[20.262656,42.775598],[20.26224,42.775502],[20.261614,42.775336],[20.260984,42.775016],[20.26051,42.774681],[20.260213,42.774157],[20.259897,42.773602],[20.259488,42.773154],[20.259121,42.772769],[20.258733,42.772226],[20.25847,42.771561],[20.258217,42.771117],[20.257765,42.7708],[20.257055,42.770483],[20.256745,42.770224],[20.256234,42.769974],[20.25577,42.769623],[20.255329,42.769374],[20.254966,42.769249],[20.254407,42.769456],[20.253945,42.769864],[20.253387,42.769909],[20.252897,42.76957],[20.252984,42.769098],[20.253576,42.768448],[20.253321,42.767786],[20.253324,42.76717],[20.253709,42.766935],[20.254213,42.766594],[20.254212,42.765683],[20.254124,42.765231],[20.25399,42.764716],[20.254241,42.764176],[20.253831,42.763609],[20.253402,42.76307],[20.25275,42.762955],[20.252246,42.762896],[20.251321,42.762865],[20.250686,42.762586],[20.250204,42.762193],[20.249872,42.761632],[20.250057,42.761108],[20.250537,42.759448],[20.250496,42.758929],[20.249743,42.758865],[20.249295,42.758931],[20.248789,42.758868],[20.248233,42.758766],[20.247678,42.758664],[20.247122,42.758562],[20.246566,42.75846],[20.246017,42.75838],[20.245284,42.758476],[20.244786,42.758492],[20.244436,42.7582],[20.244148,42.757868],[20.243646,42.757736],[20.243229,42.757622],[20.242653,42.75749],[20.242157,42.757338],[20.241601,42.757193],[20.241184,42.757084],[20.240792,42.75701],[20.240261,42.757001],[20.239705,42.756991],[20.239149,42.756981],[20.238718,42.756961],[20.238301,42.756938],[20.237884,42.756914],[20.237468,42.75689],[20.236912,42.756858],[20.236372,42.756596],[20.236139,42.756105],[20.236033,42.755717],[20.235835,42.75519],[20.235677,42.754773],[20.235416,42.754298],[20.235187,42.753881],[20.234852,42.753442],[20.234428,42.752886],[20.233865,42.752657],[20.233448,42.752574],[20.233058,42.752525],[20.23253,42.752554],[20.231974,42.752584],[20.231419,42.752614],[20.230863,42.752644],[20.230306,42.752705],[20.229691,42.752837],[20.229125,42.752862],[20.228628,42.752887],[20.22813,42.752924],[20.227694,42.752956],[20.227262,42.753009],[20.226862,42.753014],[20.226342,42.753055],[20.225828,42.753118],[20.225305,42.753142],[20.224753,42.753084],[20.224336,42.75311],[20.22395,42.753094],[20.223455,42.752966],[20.22299,42.752825],[20.222634,42.752698],[20.222275,42.752606],[20.221801,42.752619],[20.221346,42.752402],[20.220971,42.752275],[20.220612,42.752108],[20.2202,42.751952],[20.219788,42.751867],[20.219531,42.75168],[20.218933,42.751387],[20.218352,42.750997],[20.217868,42.750666],[20.217437,42.750423],[20.217106,42.750335],[20.216691,42.750042],[20.216274,42.749738],[20.215817,42.749521],[20.215304,42.749186],[20.214746,42.749106],[20.214192,42.74908],[20.213655,42.748856],[20.213162,42.748652],[20.212866,42.748178],[20.212779,42.747831],[20.212847,42.747346],[20.213134,42.747049],[20.212976,42.746601],[20.212778,42.746233],[20.212363,42.746336],[20.211699,42.746708],[20.21093,42.746846],[20.210289,42.746853],[20.20995,42.747287],[20.209585,42.747575],[20.209171,42.747904],[20.208612,42.748121],[20.207976,42.748372],[20.207176,42.748768],[20.206444,42.748905],[20.206121,42.749276],[20.205708,42.749411],[20.205105,42.749432],[20.204566,42.74952],[20.204166,42.749633],[20.203752,42.749676],[20.203469,42.749846],[20.203002,42.749897],[20.202582,42.750085],[20.201941,42.750322],[20.201399,42.750399],[20.201031,42.750214],[20.200473,42.750175],[20.200019,42.750162],[20.199488,42.75009],[20.198974,42.750013],[20.198526,42.750003],[20.19814,42.750024],[20.197759,42.750077],[20.197285,42.750055],[20.196866,42.750155],[20.196336,42.750309],[20.195785,42.750348],[20.195599,42.750065],[20.195251,42.749805],[20.194835,42.749494],[20.194279,42.749079],[20.193841,42.748761],[20.193382,42.748281],[20.192872,42.747749],[20.192522,42.74737],[20.192091,42.746852],[20.191668,42.746305],[20.191367,42.7457],[20.191077,42.745385],[20.190731,42.745764],[20.19038,42.746087],[20.189859,42.746321],[20.189385,42.746725],[20.189042,42.747086],[20.188697,42.747446],[20.188202,42.747959],[20.187798,42.748375],[20.188084,42.749371],[20.187719,42.749628],[20.187259,42.750024],[20.186783,42.750236],[20.186334,42.750286],[20.185726,42.750206],[20.185104,42.750675],[20.184695,42.751617],[20.184281,42.752274],[20.183784,42.752873],[20.183278,42.753384],[20.182858,42.753781],[20.182304,42.753428],[20.181758,42.753282],[20.181375,42.753436],[20.180951,42.753609],[20.180615,42.753884],[20.180214,42.754067],[20.179881,42.754323],[20.179558,42.754546],[20.179216,42.754742],[20.178611,42.754793],[20.178207,42.7549],[20.177802,42.754979],[20.177162,42.75494],[20.176632,42.754934],[20.17629,42.754967],[20.175914,42.755001],[20.175502,42.755061],[20.175127,42.755228],[20.174707,42.755337],[20.174219,42.755416],[20.173698,42.755553],[20.173359,42.755845],[20.173152,42.756141],[20.173207,42.756516],[20.173435,42.757072],[20.173175,42.757694],[20.172687,42.758133],[20.172092,42.758652],[20.171487,42.758943],[20.171016,42.75914],[20.170495,42.759349],[20.170055,42.759677],[20.169409,42.760222],[20.168992,42.760572],[20.168605,42.760906],[20.168217,42.761258],[20.167801,42.761637],[20.167134,42.761953],[20.166578,42.762153],[20.166022,42.762353],[20.165476,42.762564],[20.164929,42.76282],[20.164512,42.763016],[20.164095,42.763211],[20.16354,42.763471],[20.163123,42.763667],[20.162707,42.763862],[20.162151,42.764122],[20.161596,42.764383],[20.16104,42.764643],[20.160484,42.764903],[20.159929,42.765164],[20.159373,42.765424],[20.158894,42.765743],[20.158727,42.766481],[20.158316,42.767029],[20.157864,42.767456],[20.157458,42.767687],[20.15708,42.767913],[20.156673,42.768144],[20.156284,42.768326],[20.155947,42.768551],[20.155598,42.768841],[20.155026,42.7691],[20.154631,42.768539],[20.153039,42.767829],[20.152253,42.767464],[20.151207,42.766917],[20.150721,42.76659],[20.150192,42.766163],[20.149474,42.765427],[20.148856,42.764598],[20.147722,42.763658],[20.148059,42.759747],[20.147918,42.759192],[20.147812,42.758775],[20.147889,42.75821],[20.148012,42.757766],[20.148146,42.757361],[20.148222,42.756821],[20.148129,42.756246],[20.147917,42.755707],[20.147313,42.755566],[20.146877,42.754724],[20.146402,42.75468],[20.145863,42.754808],[20.145321,42.754956],[20.144958,42.755074],[20.144517,42.755094],[20.143955,42.755181],[20.143402,42.755258],[20.142891,42.755441],[20.142555,42.755725],[20.142003,42.755769],[20.141633,42.755972],[20.141103,42.756248],[20.140658,42.756316],[20.140189,42.75643],[20.139724,42.756777],[20.139328,42.75709],[20.138929,42.757327],[20.138573,42.75753],[20.138079,42.757767],[20.137523,42.758033],[20.136968,42.758299],[20.136412,42.758566],[20.135856,42.758832],[20.135301,42.759098],[20.134745,42.759364],[20.134231,42.759589],[20.133717,42.759724],[20.133162,42.759869],[20.132587,42.760029],[20.132038,42.760247],[20.13148,42.760388],[20.130856,42.760574],[20.130375,42.760745],[20.130018,42.760873],[20.12953,42.761052],[20.129056,42.761237],[20.128504,42.761267],[20.127981,42.761152],[20.127623,42.761295],[20.127263,42.761604],[20.126917,42.761961],[20.126517,42.762408],[20.125923,42.762621],[20.125265,42.762656],[20.12472,42.762638],[20.124315,42.762635],[20.123791,42.762677],[20.123221,42.762809],[20.122687,42.762836],[20.122252,42.762791],[20.121711,42.762767],[20.121055,42.762731],[20.120583,42.762485],[20.120005,42.762242],[20.119583,42.762287],[20.119214,42.762772],[20.118771,42.763119],[20.118198,42.763293],[20.117725,42.763471],[20.117341,42.763589],[20.116838,42.763702],[20.116331,42.763728],[20.11598,42.763686],[20.115379,42.763667],[20.114938,42.763386],[20.114347,42.762958],[20.11365,42.762613],[20.113171,42.76245],[20.112717,42.762442],[20.112117,42.762454],[20.111442,42.762521],[20.111011,42.76293],[20.110962,42.763367],[20.110768,42.763913],[20.110396,42.764125],[20.10998,42.76421],[20.109274,42.764291],[20.109016,42.764631],[20.108574,42.764981],[20.107907,42.765483],[20.107499,42.765775],[20.106928,42.766079],[20.106463,42.766264],[20.10603,42.766422],[20.105612,42.766864],[20.105258,42.767312],[20.104929,42.767888],[20.10554,42.768869],[20.105218,42.769378],[20.104787,42.7698],[20.104376,42.769819],[20.103992,42.769976],[20.103758,42.770207],[20.103904,42.770601],[20.104042,42.770974],[20.104229,42.771484],[20.104432,42.77204],[20.104635,42.772596],[20.104788,42.773012],[20.104312,42.773278],[20.103756,42.773588],[20.103207,42.773894],[20.102659,42.774202],[20.102242,42.774436],[20.101825,42.774671],[20.10127,42.774983],[20.100853,42.775217],[20.100436,42.775451],[20.099939,42.77573],[20.09958,42.77593],[20.099164,42.776163],[20.098608,42.776473],[20.098078,42.776715],[20.097686,42.776748],[20.09727,42.776783],[20.096682,42.776802],[20.096094,42.776748],[20.095677,42.77671],[20.095261,42.776672],[20.094649,42.77666],[20.094097,42.776711],[20.093601,42.776635],[20.093045,42.77655],[20.092628,42.776485],[20.092212,42.776422],[20.091702,42.776279],[20.091346,42.776186],[20.090852,42.776163],[20.090435,42.776144],[20.090018,42.776125],[20.089463,42.7761],[20.088903,42.775783],[20.088327,42.775367],[20.087751,42.774975],[20.087244,42.774697],[20.086675,42.77474],[20.086149,42.774812],[20.085662,42.774602],[20.085084,42.774585],[20.084532,42.774682],[20.084076,42.774769],[20.083602,42.774811],[20.082829,42.774891],[20.082244,42.774978],[20.081745,42.775058],[20.081371,42.775016],[20.080953,42.775086],[20.08046,42.775193],[20.079908,42.775105],[20.0795,42.775045],[20.079084,42.775005],[20.078667,42.774963],[20.078121,42.774957],[20.077584,42.774963],[20.077223,42.774967],[20.076807,42.774971],[20.076251,42.774976],[20.07578,42.774992],[20.075364,42.775012],[20.074947,42.775031],[20.074455,42.775019],[20.074038,42.775008],[20.073647,42.775],[20.073116,42.774996],[20.072574,42.774965],[20.07217,42.774875],[20.071834,42.774806],[20.071445,42.774857],[20.071029,42.774911],[20.070612,42.774965],[20.070093,42.774916],[20.069646,42.774939],[20.069313,42.774996],[20.068792,42.775233],[20.068237,42.775487],[20.067742,42.775691],[20.067385,42.775756],[20.067045,42.775899],[20.066795,42.776267],[20.066457,42.776528],[20.065939,42.776909],[20.065528,42.777242],[20.065179,42.777457],[20.064722,42.777712],[20.064194,42.7779],[20.063687,42.778039],[20.063321,42.778148],[20.062945,42.778273],[20.062569,42.778434],[20.062162,42.778607],[20.061755,42.778778],[20.061382,42.778927],[20.060896,42.779045],[20.060378,42.779073],[20.059944,42.778969],[20.059592,42.778742],[20.059344,42.778528],[20.058876,42.778378],[20.058552,42.778222],[20.058066,42.778148],[20.057355,42.778057],[20.05649,42.778254],[20.05592,42.778089],[20.055601,42.777808],[20.055202,42.77774],[20.054763,42.777748],[20.054393,42.777882],[20.054112,42.777662],[20.053647,42.777213],[20.053157,42.776928],[20.052521,42.776741],[20.052114,42.776652],[20.051632,42.776471],[20.05117,42.77616],[20.050642,42.77597],[20.050322,42.775829],[20.050112,42.775601],[20.049774,42.775279],[20.049231,42.774957],[20.048834,42.774553],[20.048562,42.774211],[20.048116,42.773953],[20.047736,42.773767],[20.047343,42.773492],[20.046823,42.773619],[20.046406,42.77372],[20.04599,42.773822],[20.045412,42.774183],[20.044891,42.774503],[20.044509,42.77454],[20.044108,42.774568],[20.043706,42.774571],[20.043303,42.774519],[20.0429,42.774345],[20.042454,42.773986],[20.041834,42.773592],[20.041347,42.773331],[20.04099,42.773247],[20.040593,42.773125],[20.040167,42.772922],[20.039866,42.772767],[20.039429,42.772518],[20.038874,42.7722],[20.03835,42.771643],[20.03796,42.771134],[20.037678,42.770646],[20.03737,42.770355],[20.036913,42.770092],[20.036428,42.769964],[20.035893,42.769925],[20.035408,42.7697],[20.034859,42.769479],[20.034527,42.7693],[20.034009,42.76916],[20.033442,42.768943],[20.03289,42.768449],[20.032398,42.768007],[20.031622,42.767966],[20.031448,42.76756],[20.031476,42.766984],[20.032037,42.766389],[20.031901,42.765884],[20.03145,42.765893],[20.031028,42.765956],[20.030366,42.766151],[20.029636,42.766148],[20.029239,42.766042],[20.028823,42.765986],[20.028195,42.765692],[20.027568,42.765376],[20.026993,42.765096],[20.026519,42.765072],[20.026094,42.765104],[20.025566,42.765159],[20.024965,42.765153],[20.024222,42.765013],[20.023633,42.764906],[20.022961,42.764606],[20.022412,42.764324],[20.023732,42.763125],[20.023927,42.762843],[20.024139,42.7625],[20.024288,42.762154],[20.023933,42.761778],[20.023677,42.761309],[20.023461,42.76096],[20.023242,42.760609],[20.023017,42.760262],[20.022847,42.759795],[20.022722,42.759341],[20.022602,42.758981],[20.0224,42.758621],[20.022444,42.758131],[20.022094,42.757641],[20.022073,42.757217],[20.022115,42.756801],[20.022424,42.756131],[20.022675,42.755612],[20.022774,42.755167],[20.022871,42.754775],[20.023052,42.754275],[20.023318,42.753687],[20.023592,42.753023],[20.023488,42.752551],[20.023344,42.752182],[20.023181,42.751721],[20.022647,42.751297],[20.022123,42.750876],[20.021598,42.750436],[20.021138,42.750013],[20.020851,42.749523],[20.020607,42.749106],[20.020363,42.74869],[20.020125,42.748178],[20.020158,42.747666],[20.020189,42.746979],[20.019923,42.746425],[20.019745,42.745914],[20.019836,42.745542],[20.019849,42.745172],[20.019489,42.744732],[20.018968,42.744548],[20.018553,42.744502],[20.018118,42.744464],[20.017701,42.744426],[20.017353,42.744398],[20.016909,42.744398],[20.01649,42.744519],[20.016146,42.743982],[20.015879,42.743565],[20.015545,42.743221],[20.015351,42.742815],[20.015178,42.742435],[20.015001,42.742055],[20.014804,42.741736],[20.014529,42.741239],[20.014338,42.740699],[20.014605,42.740243],[20.014737,42.739795],[20.014848,42.739431],[20.014955,42.739023],[20.015052,42.738476],[20.015135,42.737952],[20.015166,42.737566],[20.015239,42.737187],[20.015427,42.736809],[20.015627,42.736415],[20.015908,42.735883],[20.016201,42.735327],[20.016173,42.734776],[20.016075,42.734303],[20.016052,42.733919],[20.015771,42.733339],[20.015906,42.732949],[20.015895,42.732522],[20.015747,42.732073],[20.015615,42.731665],[20.015483,42.731158],[20.015325,42.730798],[20.01514,42.73041],[20.014842,42.729883],[20.014589,42.729388],[20.014624,42.729075],[20.014734,42.728708],[20.01499,42.728261],[20.015308,42.727904],[20.015648,42.727645],[20.01602,42.72742],[20.016192,42.727132],[20.016396,42.72682],[20.016729,42.726511],[20.017024,42.726188],[20.01742,42.725847],[20.017856,42.72554],[20.018092,42.725236],[20.018345,42.724767],[20.018637,42.724408],[20.01906,42.724588],[20.019544,42.724416],[20.019939,42.724206],[20.020422,42.724061],[20.02088,42.723809],[20.021439,42.723345],[20.021878,42.723127],[20.022214,42.722916],[20.022632,42.72272],[20.023018,42.722592],[20.023463,42.722468],[20.023975,42.722398],[20.024466,42.722386],[20.024991,42.722453],[20.025511,42.722536],[20.025891,42.722534],[20.026366,42.722327],[20.026771,42.72205],[20.027134,42.721761],[20.027636,42.721384],[20.028131,42.721138],[20.02868,42.72093],[20.029173,42.720725],[20.029749,42.720569],[20.030247,42.72049],[20.030699,42.720434],[20.031064,42.720401],[20.031599,42.720464],[20.032072,42.7205],[20.032186,42.720127],[20.032084,42.719784],[20.031762,42.719497],[20.031342,42.719145],[20.030972,42.718842],[20.030592,42.718594],[20.030059,42.718348],[20.029525,42.718163],[20.02897,42.71797],[20.028414,42.717776],[20.027997,42.717631],[20.027722,42.717445],[20.027734,42.71681],[20.02763,42.716246],[20.027209,42.715757],[20.026799,42.715554],[20.026372,42.715387],[20.025973,42.715309],[20.02549,42.715111],[20.025031,42.714979],[20.024556,42.714809],[20.024202,42.71467],[20.02383,42.714391],[20.02354,42.714021],[20.02294,42.7136],[20.022603,42.713273],[20.022106,42.713198],[20.02172,42.713135],[20.021315,42.713053],[20.020899,42.712961],[20.02045,42.713088],[20.019894,42.713232],[20.019339,42.713376],[20.018783,42.713519],[20.018155,42.713589],[20.017472,42.713426],[20.017028,42.713157],[20.016732,42.712798],[20.016474,42.712397],[20.016391,42.711996],[20.016305,42.711579],[20.016191,42.711024],[20.016077,42.710468],[20.016008,42.709849],[20.016328,42.709748],[20.016639,42.709714],[20.017075,42.70977],[20.01753,42.709933],[20.017991,42.709872],[20.018543,42.709951],[20.019045,42.709834],[20.019414,42.70968],[20.019972,42.709626],[20.020515,42.709616],[20.021053,42.709613],[20.021495,42.709567],[20.022066,42.709626],[20.022522,42.709625],[20.023062,42.709609],[20.023613,42.709654],[20.024107,42.709757],[20.02466,42.709929],[20.025129,42.709938],[20.025642,42.709891],[20.026195,42.709973],[20.026722,42.709869],[20.027161,42.709902],[20.027801,42.709992],[20.028306,42.71],[20.028513,42.710286],[20.02917,42.710449],[20.029767,42.710644],[20.030184,42.71081],[20.030621,42.71091],[20.031095,42.711091],[20.03144,42.711207],[20.031994,42.711457],[20.032526,42.711446],[20.032916,42.71143],[20.033321,42.711438],[20.033708,42.711428],[20.033499,42.710931],[20.033212,42.710313],[20.032939,42.709718],[20.032684,42.709163],[20.032493,42.708746],[20.032303,42.708329],[20.031995,42.707657],[20.031803,42.70724],[20.031614,42.706826],[20.031485,42.706397],[20.031544,42.705872],[20.031647,42.705347],[20.031676,42.704931],[20.031714,42.704375],[20.031752,42.70382],[20.031791,42.703264],[20.031819,42.702847],[20.031848,42.702431],[20.031876,42.702014],[20.032039,42.701462],[20.032204,42.700906],[20.032327,42.700489],[20.03245,42.700073],[20.032614,42.699517],[20.032779,42.698962],[20.032943,42.698406],[20.033066,42.697989],[20.033189,42.697573],[20.033623,42.697331],[20.034165,42.697199],[20.03472,42.697064],[20.035276,42.696929],[20.035755,42.696789],[20.036077,42.69674],[20.036473,42.696728],[20.037006,42.696727],[20.037483,42.696706],[20.037882,42.696663],[20.038314,42.696651],[20.03879,42.696628],[20.039341,42.696556],[20.039981,42.696519],[20.040717,42.696239],[20.041436,42.696245],[20.041801,42.6962],[20.042186,42.696153],[20.042591,42.696174],[20.042956,42.696205],[20.043476,42.696124],[20.04393,42.69601],[20.044413,42.695812],[20.044928,42.69555],[20.045247,42.695223],[20.045783,42.694932],[20.04627,42.694429],[20.04635,42.693945],[20.046496,42.693509],[20.046756,42.693092],[20.047166,42.69285],[20.047655,42.692742],[20.048283,42.692422],[20.048711,42.692147],[20.048963,42.691925],[20.049058,42.691612],[20.049055,42.691261],[20.049265,42.690955],[20.049394,42.690586],[20.049754,42.690414],[20.050069,42.690117],[20.050609,42.689819],[20.051133,42.689694],[20.051613,42.689299],[20.052089,42.688907],[20.052646,42.688568],[20.052924,42.688065],[20.052924,42.687618],[20.052844,42.687196],[20.053066,42.686698],[20.053199,42.686203],[20.053399,42.685895],[20.053579,42.685496],[20.053961,42.685194],[20.054138,42.684929],[20.054441,42.684881],[20.054783,42.684936],[20.055388,42.68489],[20.055912,42.684915],[20.056291,42.684935],[20.05685,42.684886],[20.057404,42.684866],[20.057847,42.684789],[20.058441,42.684481],[20.059035,42.684318],[20.059651,42.684335],[20.060152,42.684462],[20.060534,42.684593],[20.060946,42.684685],[20.061467,42.684793],[20.062036,42.68477],[20.062764,42.684877],[20.063526,42.684891],[20.063966,42.684447],[20.064522,42.68391],[20.065077,42.683374],[20.065633,42.682837],[20.066049,42.682434],[20.066466,42.682032],[20.067021,42.681495],[20.067577,42.680958],[20.068133,42.680422],[20.06881,42.680279],[20.069366,42.68027],[20.069921,42.68026],[20.070338,42.680253],[20.070755,42.680246],[20.07131,42.680237],[20.071866,42.680228],[20.072421,42.680219],[20.072977,42.680209],[20.073532,42.6802],[20.074088,42.680191],[20.074504,42.680184],[20.074921,42.680177],[20.075477,42.680168],[20.076032,42.680159],[20.076449,42.680151],[20.076866,42.680145],[20.077421,42.680136],[20.077977,42.680126],[20.078532,42.680117],[20.079088,42.680108],[20.079643,42.680099],[20.08006,42.680091],[20.080477,42.680085],[20.081032,42.680076],[20.081449,42.680068],[20.081866,42.680062],[20.082421,42.680053],[20.082838,42.680045],[20.083255,42.680039],[20.083601,42.67958],[20.083854,42.679024],[20.084044,42.678607],[20.084234,42.678191],[20.084486,42.677635],[20.084739,42.67708],[20.084929,42.676663],[20.085119,42.676246],[20.085372,42.675691],[20.085561,42.675274],[20.085727,42.674912],[20.085957,42.674411],[20.086148,42.673994],[20.08634,42.673578],[20.086595,42.673022],[20.08685,42.672467],[20.087106,42.671911],[20.087297,42.671494],[20.087488,42.671078],[20.087744,42.670522],[20.087999,42.669967],[20.08819,42.66955],[20.088382,42.669133],[20.088644,42.668688],[20.089131,42.668491],[20.089687,42.668265],[20.090103,42.668096],[20.09052,42.667927],[20.091076,42.667702],[20.091492,42.667532],[20.091909,42.667364],[20.092464,42.667138],[20.09302,42.666913],[20.093436,42.666744],[20.093853,42.666575],[20.094409,42.66635],[20.095034,42.665989],[20.09559,42.665641],[20.096145,42.665293],[20.096701,42.664945],[20.097256,42.664598],[20.097812,42.66425],[20.098367,42.663902],[20.098784,42.663641],[20.099201,42.663381],[20.099617,42.66312],[20.100139,42.662793],[20.100555,42.662533],[20.100972,42.662272],[20.101528,42.661924],[20.102083,42.661576],[20.1025,42.661315],[20.102917,42.661054],[20.103333,42.660794],[20.10375,42.660533],[20.104306,42.660185],[20.104722,42.659924],[20.105139,42.659663],[20.105555,42.659402],[20.105972,42.659141],[20.106528,42.658794],[20.107083,42.658446],[20.1075,42.658185],[20.107917,42.657924],[20.108472,42.657576],[20.108889,42.657315],[20.109306,42.657055],[20.109861,42.656707],[20.110417,42.656359],[20.110833,42.656098],[20.11125,42.655837],[20.111825,42.6555],[20.112476,42.655234],[20.112819,42.655099],[20.11302,42.654812],[20.112641,42.654451],[20.112116,42.654223],[20.111757,42.653833],[20.111277,42.653217],[20.110637,42.652806],[20.110419,42.652121],[20.110233,42.651497],[20.110053,42.651129],[20.110452,42.650627],[20.110631,42.650098],[20.110333,42.649725],[20.109997,42.649448],[20.109445,42.649218],[20.109076,42.648969],[20.108862,42.648649],[20.108912,42.648177],[20.10877,42.647819],[20.108178,42.647765],[20.107454,42.647487],[20.106637,42.64718],[20.106267,42.647108],[20.105702,42.646934],[20.105208,42.646741],[20.104847,42.64658],[20.104406,42.646331],[20.103917,42.646063],[20.103453,42.645883],[20.103066,42.645688],[20.102763,42.645444],[20.10224,42.645064],[20.101689,42.644859],[20.101341,42.64476],[20.100915,42.644636],[20.100481,42.644465],[20.099916,42.644291],[20.099459,42.644021],[20.099012,42.643777],[20.09863,42.643628],[20.098226,42.643427],[20.097709,42.643125],[20.097155,42.642732],[20.096728,42.642362],[20.096705,42.642023],[20.096494,42.641718],[20.09591,42.64122],[20.095479,42.640912],[20.09499,42.640652],[20.094524,42.6402],[20.093881,42.63966],[20.093666,42.639112],[20.093618,42.6387],[20.093555,42.638274],[20.09322,42.637829],[20.092962,42.637495],[20.09277,42.637155],[20.092516,42.636702],[20.092306,42.636178],[20.092186,42.635603],[20.092224,42.635118],[20.092277,42.634686],[20.092158,42.634242],[20.091723,42.633793],[20.091172,42.633324],[20.090659,42.633],[20.090471,42.632601],[20.090125,42.632128],[20.089907,42.631523],[20.089796,42.631092],[20.089481,42.630793],[20.089144,42.630554],[20.088775,42.630251],[20.088451,42.62975],[20.088207,42.629176],[20.087911,42.628928],[20.087432,42.628716],[20.086999,42.628329],[20.08668,42.627927],[20.086249,42.627672],[20.085751,42.627527],[20.08525,42.627406],[20.084862,42.627342],[20.084324,42.627368],[20.083908,42.627338],[20.083496,42.627221],[20.083006,42.627007],[20.082628,42.626773],[20.082185,42.626512],[20.081804,42.626255],[20.081439,42.625904],[20.080818,42.625477],[20.080528,42.625001],[20.079936,42.624487],[20.079345,42.624229],[20.078905,42.624055],[20.078567,42.623865],[20.078256,42.623653],[20.077916,42.623152],[20.077428,42.622538],[20.077149,42.621962],[20.076811,42.621374],[20.076193,42.620929],[20.075783,42.620642],[20.075894,42.620117],[20.075886,42.619592],[20.07585,42.61916],[20.075861,42.618827],[20.075909,42.618331],[20.075925,42.617756],[20.075922,42.617366],[20.075944,42.616934],[20.075934,42.616469],[20.075716,42.615996],[20.075691,42.615502],[20.075899,42.615062],[20.076174,42.614502],[20.076047,42.614042],[20.075824,42.613684],[20.075661,42.613256],[20.075389,42.612908],[20.075199,42.612432],[20.075229,42.61203],[20.075143,42.611684],[20.075222,42.611282],[20.074943,42.610888],[20.074717,42.610597],[20.074442,42.610279],[20.074013,42.609604],[20.073645,42.609103],[20.073244,42.608695],[20.072877,42.608209],[20.072763,42.607771],[20.072761,42.607273],[20.072848,42.606761],[20.072979,42.606394],[20.073333,42.605817],[20.073673,42.60546],[20.07416,42.605154],[20.074521,42.604562],[20.074679,42.603946],[20.074694,42.60347],[20.074773,42.602845],[20.074804,42.602352],[20.074918,42.601947],[20.075289,42.601266],[20.075687,42.600734],[20.076031,42.600334],[20.076461,42.599755],[20.076782,42.599444],[20.077034,42.599155],[20.077263,42.598859],[20.077476,42.598595],[20.077782,42.59826],[20.078142,42.598022],[20.078502,42.597886],[20.078976,42.597653],[20.079259,42.597196],[20.079534,42.596697],[20.07971,42.596225],[20.07981,42.59582],[20.07981,42.59531],[20.080498,42.594896],[20.080773,42.594532],[20.080825,42.594183],[20.08104,42.593812],[20.081049,42.593114],[20.081089,42.5922],[20.08127,42.591732],[20.081478,42.591225],[20.082056,42.591066],[20.082486,42.590873],[20.083003,42.590677],[20.083506,42.590391],[20.083919,42.59002],[20.084281,42.589603],[20.084725,42.589094],[20.084889,42.588625],[20.085463,42.588424],[20.085889,42.587717],[20.086232,42.587245],[20.086336,42.586759],[20.086205,42.586321],[20.086062,42.585839],[20.085629,42.585316],[20.08569,42.58482],[20.085811,42.584402],[20.085851,42.583946],[20.085829,42.583548],[20.085781,42.583101],[20.085749,42.582573],[20.086257,42.582104],[20.086784,42.581754],[20.087076,42.581455],[20.087247,42.581053],[20.08732,42.580586],[20.087383,42.580169],[20.087445,42.579752],[20.087507,42.579336],[20.087575,42.578757],[20.088073,42.578381],[20.088335,42.577911],[20.088382,42.577238],[20.088366,42.576807],[20.088333,42.576375],[20.088151,42.575832],[20.088097,42.575356],[20.088133,42.574782],[20.088173,42.574095],[20.087676,42.57347],[20.087005,42.572923],[20.086601,42.572549],[20.086016,42.572259],[20.085597,42.571951],[20.084996,42.571537],[20.084695,42.571329],[20.084302,42.571042],[20.08398,42.570595],[20.083845,42.570143],[20.083935,42.569734],[20.084074,42.569323],[20.084131,42.568949],[20.084003,42.568449],[20.084445,42.568267],[20.084215,42.567921],[20.083804,42.56737],[20.083752,42.566878],[20.083379,42.566538],[20.082806,42.566166],[20.082754,42.565476],[20.082443,42.564887],[20.082008,42.564309],[20.081552,42.563799],[20.081335,42.563185],[20.080913,42.56264],[20.080685,42.562259],[20.080528,42.561893],[20.080378,42.561543],[20.080314,42.561168],[20.079891,42.560848],[20.079581,42.56059],[20.079226,42.560073],[20.079102,42.559578],[20.078979,42.559276],[20.0789,42.558898],[20.078883,42.558456],[20.078777,42.558109],[20.078855,42.55756],[20.078919,42.556789],[20.078889,42.556229],[20.078895,42.555799],[20.077818,42.555968],[20.076968,42.556265],[20.076117,42.556314],[20.075136,42.556215],[20.074547,42.555968],[20.073892,42.555819],[20.073107,42.555671],[20.072387,42.55577],[20.070817,42.555968],[20.06977,42.556314],[20.069181,42.55671],[20.068003,42.557006],[20.06676,42.556759],[20.065582,42.556858],[20.064797,42.557006],[20.063881,42.557451],[20.063423,42.557748],[20.062507,42.558243],[20.061722,42.558589],[20.060086,42.558836],[20.059039,42.558984],[20.057861,42.559083],[20.055833,42.559257],[20.055048,42.558737],[20.054197,42.557649],[20.053674,42.556561],[20.053085,42.555523],[20.050664,42.55211],[20.049944,42.551468],[20.048701,42.550627],[20.048308,42.550231],[20.046542,42.549737],[20.045102,42.549489],[20.043793,42.549292],[20.042092,42.548945],[20.040783,42.548649],[20.039606,42.548055],[20.037839,42.54761],[20.034764,42.546819],[20.03195,42.546275],[20.030249,42.545879],[20.029071,42.545286],[20.027632,42.544247],[20.026585,42.543852],[20.024556,42.543308],[20.022331,42.543505],[20.019583,42.543753],[20.018209,42.543901],[20.01605,42.543407],[20.01533,42.542665],[20.014741,42.542022],[20.01461,42.540983],[20.014283,42.539945],[20.013956,42.538214],[20.013629,42.537175],[20.014022,42.536186],[20.014283,42.535642],[20.014741,42.534357],[20.014872,42.532922],[20.01533,42.531834],[20.015526,42.530845],[20.015461,42.530301],[20.014545,42.529016],[20.013891,42.527878],[20.013302,42.527037],[20.012386,42.526345],[20.012059,42.525949],[20.011993,42.524664],[20.011993,42.523872],[20.011731,42.522784],[20.011143,42.521696],[20.009965,42.52051],[20.008787,42.51957],[20.008263,42.518334],[20.008329,42.516998],[20.00846,42.515762],[20.00846,42.514723],[20.008133,42.51413],[20.007413,42.513141],[20.005973,42.5123],[20.004861,42.511459],[20.003487,42.510619],[20.002833,42.509828],[20.001982,42.509531],[20.000281,42.510174],[19.997925,42.510915],[19.996747,42.511361],[19.994523,42.512003],[19.993083,42.512449],[19.991905,42.512795],[19.990793,42.512894],[19.989615,42.512844],[19.987456,42.512745],[19.985689,42.512745],[19.984381,42.512844],[19.982352,42.512894],[19.981371,42.513339],[19.980455,42.513635],[19.978688,42.513487],[19.977314,42.513091],[19.976463,42.512844],[19.975809,42.512646],[19.974697,42.512498],[19.972472,42.512646],[19.971098,42.512399],[19.970247,42.512003],[19.96848,42.511163],[19.968088,42.510817],[19.966714,42.51047],[19.96462,42.51052],[19.962526,42.510965],[19.960956,42.511064],[19.959189,42.511459],[19.957226,42.511806],[19.954674,42.511905],[19.953104,42.511905],[19.952319,42.512102],[19.951206,42.51319],[19.950225,42.513883],[19.949309,42.514278],[19.947607,42.514872],[19.946561,42.515366],[19.946103,42.516504],[19.943812,42.517888],[19.943093,42.518432],[19.942111,42.51863],[19.940868,42.518432],[19.938709,42.517691],[19.937596,42.516949],[19.936157,42.516751],[19.934128,42.516553],[19.932035,42.516084],[19.929286,42.514773],[19.928174,42.514278],[19.923725,42.512646],[19.922154,42.511657],[19.920976,42.510668],[19.919799,42.509877],[19.917705,42.50874],[19.916462,42.508097],[19.914695,42.50775],[19.91319,42.507404],[19.911227,42.507206],[19.909918,42.50686],[19.907628,42.507058],[19.906647,42.507652],[19.905731,42.507899],[19.905273,42.506959],[19.9056,42.505624],[19.905403,42.504388],[19.904749,42.5033],[19.903899,42.502261],[19.903899,42.500679],[19.903833,42.499096],[19.904029,42.497959],[19.90416,42.496722],[19.904815,42.494596],[19.905011,42.493162],[19.904618,42.492024],[19.903833,42.490837],[19.902721,42.489997],[19.901543,42.489403],[19.900496,42.488958],[19.89958,42.488612],[19.899384,42.48787],[19.89886,42.48693],[19.898206,42.486238],[19.897224,42.485595],[19.896636,42.485298],[19.896047,42.485249],[19.895,42.485941],[19.893887,42.486881],[19.892382,42.48787],[19.89055,42.488711],[19.889111,42.489205],[19.887802,42.490095],[19.886886,42.49148],[19.886559,42.492568],[19.885708,42.493706],[19.884661,42.494546],[19.883091,42.49509],[19.881586,42.495535],[19.880801,42.495733],[19.878838,42.495931],[19.877725,42.495832],[19.875828,42.495535],[19.875435,42.494843],[19.875239,42.494002],[19.875108,42.492964],[19.875435,42.491727],[19.875959,42.490837],[19.874846,42.490392],[19.873996,42.490293],[19.873014,42.4897],[19.872753,42.489057],[19.872753,42.488414],[19.872883,42.487079],[19.872556,42.485991],[19.87236,42.485397],[19.871117,42.484754],[19.870135,42.48426],[19.869154,42.483469],[19.867911,42.48243],[19.867256,42.482133],[19.865751,42.482035],[19.864116,42.481936],[19.862545,42.482282],[19.861564,42.482776],[19.859993,42.483419],[19.859012,42.483963],[19.85803,42.484458],[19.85718,42.484408],[19.854955,42.483963],[19.853515,42.483815],[19.852992,42.48332],[19.852599,42.482282],[19.852207,42.481688],[19.851683,42.481194],[19.851094,42.48065],[19.850702,42.480155],[19.850375,42.47976],[19.849459,42.479216],[19.848608,42.479117],[19.846318,42.479315],[19.84357,42.479562],[19.841083,42.480056],[19.840494,42.480056],[19.839644,42.479859],[19.838466,42.479463],[19.837615,42.479265],[19.836896,42.479067],[19.836438,42.478721],[19.836568,42.47788],[19.837746,42.475952],[19.838597,42.474468],[19.838204,42.473726],[19.837484,42.472638],[19.835914,42.471105],[19.834671,42.469622],[19.832773,42.467742],[19.832184,42.46705],[19.831268,42.466407],[19.829829,42.466654],[19.824136,42.468484],[19.820014,42.469622],[19.816742,42.470611],[19.815695,42.471006],[19.814845,42.471995],[19.814256,42.472985],[19.813929,42.473331],[19.812358,42.473924],[19.81033,42.474567],[19.808367,42.475309],[19.806339,42.475952],[19.804114,42.477139],[19.801955,42.478474],[19.799206,42.479512],[19.797114,42.480314],[19.793401,42.481909],[19.791654,42.482569],[19.790053,42.484769],[19.787723,42.487465],[19.785467,42.490271],[19.783137,42.493241],[19.782045,42.494727],[19.780589,42.496762],[19.778041,42.497477],[19.772654,42.499073],[19.769014,42.500228],[19.766102,42.501218],[19.765593,42.501493],[19.763991,42.502648],[19.763409,42.503914],[19.762899,42.505399],[19.761735,42.510185],[19.761225,42.511835],[19.760497,42.513101],[19.760206,42.515246],[19.759842,42.516291],[19.759915,42.517391],[19.759842,42.520142],[19.759478,42.520527],[19.758386,42.522123],[19.758095,42.523443],[19.756857,42.524488],[19.755037,42.525313],[19.754164,42.527184],[19.753144,42.528284],[19.752635,42.528724],[19.752635,42.529274],[19.752271,42.530429],[19.752489,42.531254],[19.753436,42.53186],[19.753436,42.532575],[19.752489,42.533565],[19.752198,42.53417],[19.751288,42.53472],[19.750888,42.535325],[19.75016,42.535435],[19.749577,42.535105],[19.748631,42.535875],[19.747903,42.536206],[19.74783,42.537306],[19.747612,42.538076],[19.747685,42.538846],[19.747102,42.539451],[19.745937,42.540166],[19.745792,42.541872],[19.745355,42.542422],[19.7447,42.542807],[19.744336,42.543687],[19.743681,42.544457],[19.743608,42.545117],[19.743826,42.545778],[19.743826,42.546328],[19.74419,42.547318],[19.745501,42.548418],[19.746738,42.548803],[19.747903,42.549023],[19.748631,42.549793],[19.749141,42.550399],[19.749723,42.551114],[19.74965,42.551664],[19.749359,42.552104],[19.749141,42.552819],[19.748922,42.553369],[19.748995,42.553864],[19.749286,42.554745],[19.748777,42.55568],[19.748849,42.556395],[19.749068,42.557495],[19.749796,42.5581],[19.750087,42.558815],[19.750379,42.559476],[19.751106,42.560576],[19.751616,42.561346],[19.752271,42.561676],[19.752926,42.562226],[19.753144,42.563106],[19.753436,42.563601],[19.753909,42.56451],[19.753872,42.565087],[19.754164,42.565637],[19.754091,42.566242],[19.753581,42.567122],[19.752635,42.567452],[19.751834,42.567672],[19.751106,42.568222],[19.750378,42.568552],[19.749577,42.569378],[19.748995,42.570478],[19.748777,42.571358],[19.748485,42.573118],[19.748922,42.574329],[19.749213,42.575539],[19.750087,42.576584],[19.75096,42.577299],[19.752344,42.577794],[19.752635,42.57818],[19.752052,42.579115],[19.751834,42.57972],[19.752271,42.5806],[19.752635,42.581095],[19.753072,42.58126],[19.754164,42.581095],[19.75511,42.58104],[19.755838,42.58093],[19.756275,42.580435],[19.756784,42.580105],[19.757876,42.57994],[19.758968,42.580215],[19.759478,42.580545],[19.759696,42.58181],[19.760715,42.582801],[19.761589,42.583186],[19.762171,42.583241],[19.762972,42.583461],[19.763554,42.583516],[19.764719,42.582911],[19.765593,42.583076],[19.766175,42.583241],[19.767049,42.582801],[19.768359,42.582746],[19.771708,42.582525],[19.772727,42.58258],[19.773819,42.58258],[19.774765,42.582856],[19.775056,42.584011],[19.774329,42.585661],[19.775056,42.585936],[19.775348,42.587256],[19.775202,42.588027],[19.774401,42.589237],[19.774692,42.590447],[19.774692,42.591217],[19.774329,42.592098],[19.774037,42.592538],[19.773673,42.593088],[19.773164,42.593528],[19.772145,42.594848],[19.771417,42.596003],[19.771053,42.596498],[19.770106,42.597434],[19.767922,42.599194],[19.76734,42.599689],[19.766758,42.600239],[19.766248,42.601064],[19.765593,42.60156],[19.76501,42.602],[19.761225,42.605355],[19.759259,42.606841],[19.758968,42.607501],[19.759915,42.610361],[19.758823,42.611022],[19.754382,42.612617],[19.752489,42.613442],[19.751252,42.614102],[19.751761,42.617018],[19.752926,42.620319],[19.752198,42.621364],[19.751252,42.622244],[19.750305,42.623289],[19.749869,42.624169],[19.749505,42.625765],[19.749432,42.62758],[19.749723,42.62901],[19.750596,42.630551],[19.751761,42.631431],[19.753654,42.632366],[19.754892,42.633301],[19.755984,42.634512],[19.756639,42.635062],[19.75693,42.635997],[19.756711,42.636547],[19.755692,42.637372],[19.754528,42.638307],[19.752198,42.639793],[19.749505,42.640948],[19.748631,42.641113],[19.747685,42.640948],[19.745865,42.640838],[19.743608,42.641113],[19.742079,42.641333],[19.740478,42.642158],[19.739022,42.642323],[19.738003,42.642378],[19.737639,42.642653],[19.737711,42.643149],[19.737275,42.643699],[19.737493,42.644909],[19.737639,42.646119],[19.737129,42.647329],[19.736838,42.648595],[19.736765,42.6492],[19.735819,42.64964],[19.735455,42.65074],[19.735163,42.651125],[19.734581,42.65206],[19.734872,42.652996],[19.735018,42.653436],[19.733707,42.655526],[19.732761,42.656901],[19.73196,42.657397],[19.731742,42.657837],[19.731232,42.658882],[19.730286,42.659597],[19.728976,42.660202],[19.728102,42.660532],[19.727083,42.660752],[19.7265,42.660807],[19.7257,42.660642],[19.725263,42.660532],[19.724244,42.661027],[19.723516,42.661082],[19.722861,42.660917],[19.722205,42.660477],[19.721113,42.660092],[19.720094,42.659817],[19.718784,42.659157],[19.717983,42.658552],[19.71711,42.658167],[19.716163,42.658057],[19.713906,42.657452],[19.714052,42.657011],[19.713906,42.656571],[19.713397,42.656186],[19.712159,42.655636],[19.710631,42.655746],[19.709975,42.655691],[19.709247,42.655416],[19.708665,42.655196],[19.707646,42.654921],[19.706554,42.654756],[19.705826,42.654756],[19.705462,42.655526],[19.704952,42.655911],[19.704152,42.656241],[19.70386,42.655471],[19.704006,42.654371],[19.70386,42.653436],[19.70306,42.65228],[19.70255,42.651895],[19.701822,42.651235],[19.701167,42.651235],[19.700148,42.650795],[19.698765,42.650465],[19.698473,42.64931],[19.699565,42.64788],[19.699784,42.646999],[19.699784,42.645679],[19.699457,42.644689],[19.697381,42.644359],[19.696362,42.644194],[19.695634,42.644139],[19.695125,42.643479],[19.694688,42.642598],[19.694033,42.641663],[19.693378,42.640948],[19.693232,42.640563],[19.692941,42.639793],[19.692358,42.639298],[19.690684,42.638968],[19.688282,42.639078],[19.687627,42.639518],[19.68668,42.638638],[19.685989,42.637152],[19.686316,42.636217],[19.685807,42.635612],[19.684787,42.635007],[19.684569,42.634017],[19.683987,42.633136],[19.683841,42.632641],[19.685443,42.631871],[19.685515,42.630936],[19.685661,42.630386],[19.685952,42.629726],[19.686607,42.629616],[19.686971,42.6289],[19.686753,42.62802],[19.685006,42.62824],[19.684278,42.628075],[19.683477,42.627635],[19.682531,42.62736],[19.681803,42.62725],[19.680128,42.62736],[19.679328,42.627855],[19.677217,42.6278],[19.675761,42.6278],[19.674814,42.62835],[19.674159,42.62835],[19.673649,42.62813],[19.672703,42.628515],[19.672048,42.6289],[19.671829,42.629396],[19.671465,42.629616],[19.6695,42.630111],[19.668554,42.629891],[19.667826,42.629946],[19.667025,42.629891],[19.666442,42.629671],[19.665423,42.629781],[19.664914,42.629671],[19.663676,42.629341],[19.66273,42.62879],[19.662147,42.62824],[19.661347,42.62648],[19.660691,42.62505],[19.660182,42.624389],[19.65858,42.622684],[19.655304,42.619163],[19.651082,42.614817],[19.645477,42.608876],[19.641254,42.60464],[19.638925,42.60222],[19.638488,42.601615],[19.637615,42.601009],[19.63463,42.598809],[19.632009,42.596223],[19.628733,42.593913],[19.62735,42.592978],[19.62735,42.592538],[19.627714,42.592208],[19.62786,42.591822],[19.627423,42.590997],[19.625312,42.588962],[19.623419,42.587367],[19.622764,42.586596],[19.620143,42.584231],[19.617741,42.58225],[19.615047,42.57972],[19.6133,42.578235],[19.612281,42.576969],[19.611189,42.575319],[19.610607,42.574604],[19.610534,42.573724],[19.611116,42.572568],[19.612499,42.570038],[19.612354,42.569488],[19.612208,42.569103],[19.611771,42.568442],[19.611553,42.567122],[19.611262,42.566517],[19.610607,42.565472],[19.609588,42.563876],[19.609733,42.562666],[19.609806,42.561841],[19.610316,42.560026],[19.610607,42.559255],[19.610898,42.55788],[19.61148,42.555625],[19.611844,42.554745],[19.612354,42.553809],[19.61381,42.552544],[19.614756,42.551719],[19.615411,42.550894],[19.615339,42.550234],[19.615484,42.549133],[19.616067,42.548253],[19.616722,42.547593],[19.61694,42.546988],[19.616503,42.545723],[19.616212,42.544347],[19.615994,42.543797],[19.616722,42.542807],[19.617304,42.542092],[19.617377,42.541432],[19.616212,42.540276],[19.613737,42.539121],[19.611917,42.538406],[19.610388,42.538131],[19.608932,42.537856],[19.60784,42.537801],[19.60704,42.537251],[19.606676,42.536481],[19.606457,42.535875],[19.605875,42.535325],[19.604492,42.53494],[19.6034,42.534665],[19.6034,42.534225],[19.603982,42.533015],[19.604055,42.5323],[19.603837,42.531585],[19.603181,42.530704],[19.601725,42.529769],[19.600269,42.529054],[19.595465,42.527184],[19.590951,42.525258],[19.584836,42.522728],[19.580177,42.520857],[19.575737,42.519097],[19.570786,42.517116],[19.567729,42.515796],[19.565982,42.515026],[19.564817,42.514641],[19.563288,42.514366],[19.56176,42.514311],[19.562269,42.513376],[19.562487,42.51167],[19.562633,42.509525],[19.562342,42.507379],[19.562051,42.505729],[19.561104,42.503914],[19.561032,42.502373],[19.560522,42.501218],[19.560085,42.500063],[19.560147,42.498936],[19.559994,42.498011],[19.559841,42.497144],[19.559535,42.495757],[19.559382,42.494803],[19.559458,42.494138],[19.559229,42.493618],[19.558693,42.493155],[19.557852,42.492982],[19.557316,42.492288],[19.556628,42.49119],[19.556093,42.490207],[19.555328,42.489802],[19.553721,42.489282],[19.550891,42.488357],[19.549896,42.487952],[19.549131,42.487259],[19.54829,42.486854],[19.548137,42.48616],[19.547601,42.485524],[19.546071,42.484715],[19.545459,42.483443],[19.544388,42.481998],[19.543088,42.480958],[19.541787,42.479108],[19.540869,42.477084],[19.540181,42.475177],[19.539492,42.474541],[19.538498,42.473674],[19.538192,42.472749],[19.538268,42.472286],[19.538192,42.471708],[19.537962,42.470205],[19.53758,42.468586],[19.537656,42.467777],[19.53735,42.466563],[19.537121,42.465869],[19.535973,42.465002],[19.535208,42.464482],[19.53452,42.463904],[19.533908,42.462921],[19.533372,42.461996],[19.533143,42.461245],[19.532684,42.460493],[19.531919,42.459453],[19.531077,42.458643],[19.529241,42.458007],[19.526564,42.457082],[19.525263,42.456215],[19.524192,42.455117],[19.522892,42.453383],[19.521821,42.4524],[19.521132,42.451706],[19.519985,42.450087],[19.519526,42.448411],[19.519602,42.44737],[19.518914,42.44633],[19.518761,42.445405],[19.518837,42.444133],[19.518531,42.443208],[19.518149,42.442514],[19.517613,42.442341],[19.51593,42.441763],[19.5144,42.441416],[19.512335,42.441185],[19.510805,42.440433],[19.51004,42.439971],[19.507668,42.439219],[19.506444,42.438699],[19.50522,42.438352],[19.503537,42.43789],[19.502925,42.437485],[19.502543,42.43656],[19.502237,42.435635],[19.501854,42.434768],[19.501013,42.433959],[19.4991,42.43286],[19.498605,42.431627],[19.498416,42.431199],[19.498152,42.430228],[19.497887,42.4292],[19.497774,42.428543],[19.497963,42.427858],[19.498114,42.42703],[19.498378,42.426002],[19.498454,42.425259],[19.498492,42.424431],[19.498416,42.423346],[19.498265,42.422746],[19.49766,42.422575],[19.496867,42.422603],[19.495922,42.422775],[19.495393,42.42286],[19.494524,42.422918],[19.493919,42.422889],[19.49339,42.422689],[19.492824,42.421889],[19.492106,42.420319],[19.491312,42.419034],[19.49067,42.417578],[19.489574,42.414922],[19.488969,42.413922],[19.48878,42.413066],[19.488554,42.412152],[19.488478,42.411552],[19.488365,42.410867],[19.488214,42.410181],[19.487609,42.409239],[19.486891,42.408325],[19.485342,42.407012],[19.484246,42.406212],[19.483112,42.405327],[19.48179,42.404213],[19.481034,42.403642],[19.480354,42.403042],[19.479938,42.4023],[19.479409,42.401043],[19.47888,42.39993],[19.478049,42.398473],[19.477255,42.396732],[19.476764,42.395332],[19.476084,42.39399],[19.474988,42.393333],[19.474232,42.392819],[19.473854,42.392448],[19.473552,42.391706],[19.473061,42.391063],[19.471852,42.390421],[19.470567,42.389878],[19.470189,42.389592],[19.469509,42.388736],[19.468148,42.38825],[19.466259,42.388022],[19.465352,42.387822],[19.464256,42.387308],[19.46044,42.385709],[19.458399,42.384766],[19.456963,42.384195],[19.455792,42.383738],[19.455263,42.383567],[19.453336,42.383424],[19.4502,42.383596],[19.448537,42.383738],[19.448083,42.383767],[19.447517,42.383567],[19.44506,42.382796],[19.443587,42.382196],[19.44268,42.38174],[19.441206,42.381054],[19.438221,42.379826],[19.436823,42.379141],[19.43584,42.378598],[19.435538,42.378313],[19.43482,42.377627],[19.43414,42.376742],[19.43346,42.376171],[19.432553,42.375114],[19.432175,42.374743],[19.431041,42.374029],[19.430021,42.373401],[19.428888,42.372573],[19.427792,42.371916],[19.426696,42.371231],[19.426167,42.370403],[19.425827,42.369489],[19.426356,42.368404],[19.426242,42.367861],[19.425902,42.36749],[19.42492,42.367062],[19.424164,42.366833],[19.423748,42.366405],[19.423522,42.365777],[19.423333,42.365006],[19.423182,42.364006],[19.423144,42.363264],[19.423257,42.362236],[19.423408,42.361493],[19.42356,42.360808],[19.424618,42.358495],[19.42492,42.357495],[19.424882,42.357067],[19.424769,42.356382],[19.424655,42.355953],[19.423937,42.355296],[19.422615,42.354268],[19.42167,42.353355],[19.420952,42.352755],[19.420385,42.35227],[19.419176,42.35187],[19.417929,42.351242],[19.416191,42.35047],[19.415171,42.350099],[19.41468,42.349871],[19.41468,42.349385],[19.414868,42.348729],[19.41536,42.345987],[19.415738,42.344217],[19.416153,42.342132],[19.416342,42.340162],[19.416493,42.338448],[19.41672,42.336021],[19.416758,42.335364],[19.417211,42.33465],[19.418307,42.333223],[19.419705,42.331424],[19.420725,42.330167],[19.421179,42.329453],[19.421784,42.328711],[19.422048,42.328225],[19.422294,42.326897],[19.421368,42.326169],[19.416229,42.321829],[19.413659,42.319744],[19.412034,42.318288],[19.407991,42.314947],[19.406215,42.313433],[19.404099,42.311634],[19.401605,42.309549],[19.398431,42.307008],[19.395824,42.305066],[19.393519,42.302896],[19.392763,42.302239],[19.391969,42.301754],[19.390949,42.30104],[19.39042,42.300611],[19.38906,42.298898],[19.387926,42.297156],[19.386415,42.2953],[19.385432,42.294272],[19.385054,42.293672],[19.384658,42.292816],[19.384601,42.291159],[19.384828,42.28936],[19.385017,42.287904],[19.385205,42.286476],[19.385243,42.284591],[19.385243,42.283335],[19.38513,42.282821],[19.384601,42.281793],[19.384374,42.281365],[19.382258,42.279537],[19.380369,42.277766],[19.379122,42.276539],[19.376477,42.273826],[19.375154,42.272398],[19.373869,42.271084],[19.371224,42.2684],[19.369977,42.267001],[19.368201,42.26523],[19.366916,42.264059],[19.365783,42.262432],[19.364687,42.26129],[19.363553,42.260062],[19.362646,42.259148],[19.361853,42.258205],[19.360946,42.257177],[19.359926,42.255892],[19.359132,42.254493],[19.357696,42.252637],[19.357243,42.251837],[19.356714,42.250981],[19.35626,42.250124],[19.354149,42.24675],[19.352489,42.244052],[19.350331,42.24079],[19.349999,42.240225],[19.346927,42.23759],[19.341697,42.232822],[19.335886,42.227804],[19.332732,42.225043],[19.327253,42.220213],[19.32003,42.213751],[19.316461,42.210677],[19.313306,42.208042],[19.310401,42.205282],[19.305088,42.200765],[19.29853,42.194993],[19.295873,42.192798],[19.289555,42.187471],[19.314259,42.173343],[19.345018,42.155752],[19.377151,42.137375],[19.4121,42.117387],[19.402214,42.10279],[19.388932,42.082447],[19.386276,42.07862],[19.384948,42.07724],[19.383868,42.076299],[19.383204,42.07517],[19.38254,42.073915],[19.38171,42.073037],[19.380216,42.072033],[19.378971,42.071218],[19.379137,42.070214],[19.379967,42.068834],[19.380548,42.067767],[19.380133,42.06576],[19.379054,42.062184],[19.37814,42.059235],[19.377891,42.057792],[19.378472,42.05591],[19.378722,42.055095],[19.37922,42.052836],[19.380216,42.050891],[19.380465,42.05039],[19.378971,42.049072],[19.378223,42.048068],[19.377476,42.047002],[19.376397,42.045622],[19.375733,42.044304],[19.37482,42.042422],[19.374073,42.04054],[19.372828,42.039097],[19.371831,42.038219],[19.371499,42.037027],[19.371333,42.035835],[19.371167,42.034392],[19.370586,42.033137],[19.371997,42.031506],[19.372163,42.030754],[19.371748,42.029875],[19.371333,42.028746],[19.371748,42.027491],[19.372246,42.025233],[19.372661,42.024606],[19.37399,42.023414],[19.374654,42.022661],[19.37482,42.021469],[19.374073,42.01965],[19.373409,42.018018],[19.373243,42.016575],[19.373243,42.015572],[19.373243,42.014631],[19.37399,42.013],[19.374571,42.011055],[19.37482,42.009988],[19.374737,42.009047],[19.375318,42.006977],[19.375982,42.005848],[19.376978,42.00453],[19.378639,42.00384],[19.380465,42.002962],[19.381295,42.002272],[19.382457,42.000014],[19.382457,41.99901],[19.382125,41.997755],[19.38171,41.996563],[19.380797,41.995246],[19.38005,41.993552],[19.379718,41.99167],[19.379552,41.990039],[19.379718,41.987968],[19.379967,41.987153],[19.380299,41.986024],[19.379884,41.984643],[19.379137,41.983326],[19.378057,41.98182],[19.377476,41.981068],[19.376978,41.980315],[19.37648,41.97906],[19.375899,41.978056],[19.37565,41.976802],[19.375401,41.976049],[19.375235,41.975359],[19.375401,41.974606],[19.376065,41.97379],[19.378057,41.972724],[19.379718,41.972159],[19.381295,41.971595],[19.382872,41.970905],[19.38445,41.969775],[19.386608,41.96827],[19.387687,41.967203],[19.387936,41.96645],[19.387355,41.965258],[19.385944,41.964066],[19.384699,41.963],[19.383453,41.962184],[19.382623,41.961683],[19.38088,41.961243],[19.37399,41.960365],[19.371499,41.959926],[19.370171,41.959675],[19.367598,41.95955],[19.362783,41.9598],[19.360043,41.959989],[19.358881,41.9598],[19.357802,41.95955],[19.356059,41.959236],[19.354066,41.958609],[19.352157,41.957856],[19.35141,41.957166],[19.350497,41.956476],[19.349832,41.955472],[19.349666,41.954782],[19.350165,41.953213],[19.350497,41.95221],[19.350663,41.951206],[19.350331,41.949261],[19.349832,41.947881],[19.349168,41.946187],[19.34867,41.944242],[19.348753,41.942047],[19.349168,41.940855],[19.349916,41.9396],[19.351991,41.937718],[19.354564,41.93571],[19.356723,41.934518],[19.359296,41.933013],[19.362534,41.93157],[19.365771,41.929939],[19.3671,41.928621],[19.368013,41.927618],[19.369092,41.926426],[19.369673,41.925547],[19.370088,41.924167],[19.370088,41.92285],[19.369424,41.92147],[19.368843,41.920528],[19.3671,41.919148],[19.365522,41.918207],[19.364443,41.917643],[19.36353,41.917141],[19.361704,41.916513],[19.358964,41.915949],[19.355727,41.915447],[19.352074,41.914631],[19.3495,41.91413],[19.348172,41.913502],[19.346097,41.912875],[19.344769,41.91231],[19.343689,41.911432],[19.342527,41.910428],[19.342195,41.909989],[19.341614,41.908232],[19.341863,41.907291],[19.342029,41.90635],[19.342527,41.905409],[19.343025,41.904908],[19.345931,41.903088],[19.348919,41.901896],[19.351576,41.900892],[19.353153,41.900516],[19.355477,41.900453],[19.358881,41.899951],[19.361288,41.899638],[19.362119,41.899324],[19.363779,41.89876],[19.36519,41.898007],[19.365937,41.897003],[19.366269,41.895999],[19.366435,41.894807],[19.366599,41.894063],[19.366767,41.893302],[19.36685,41.891859],[19.366933,41.890918],[19.367093,41.890156],[19.36702,41.889875],[19.367146,41.889581],[19.368014,41.888502],[19.370212,41.887572],[19.377311,41.887319],[19.380081,41.886259],[19.380184,41.88622],[19.380775,41.885291],[19.380353,41.884023],[19.37957,41.883083],[19.375367,41.878614],[19.373491,41.878145],[19.373306,41.877918],[19.367472,41.875389],[19.358305,41.874554],[19.355,41.872917],[19.35161,41.872917],[19.34664,41.870388],[19.341667,41.870445],[19.340778,41.869556],[19.337473,41.869583],[19.336666,41.868778],[19.334972,41.868752],[19.332916,41.870834],[19.331194,41.875832],[19.327499,41.879612],[19.324167,41.881279],[19.322472,41.881248],[19.318333,41.884583],[19.3125,41.888779],[19.305805,41.892113],[19.301666,41.892887],[19.300806,41.893749],[19.295834,41.893723],[19.294945,41.894585],[19.290833,41.894585],[19.288334,41.896252],[19.286638,41.896278],[19.283306,41.897945],[19.281666,41.899582],[19.276695,41.902084],[19.268333,41.902916],[19.267471,41.903778],[19.263334,41.903778],[19.262472,41.904556],[19.259945,41.904583],[19.259138,41.905418],[19.255777,41.905418],[19.254999,41.906277],[19.247473,41.907082],[19.244139,41.908749],[19.236639,41.908749],[19.23625,41.910831],[19.239944,41.91375],[19.245001,41.913723],[19.248306,41.915443],[19.252445,41.91539],[19.253305,41.914585],[19.254999,41.914555],[19.255806,41.915443],[19.260778,41.915443],[19.261612,41.916279],[19.26664,41.917084],[19.267471,41.917946],[19.275,41.91711],[19.275862,41.916248],[19.279972,41.919582],[19.281666,41.919613],[19.283306,41.921276],[19.285833,41.921276],[19.288305,41.92289],[19.294138,41.922943],[19.295,41.922085],[19.298277,41.922085],[19.300028,41.922916],[19.302917,41.926666],[19.302473,41.92878],[19.301666,41.927891],[19.299194,41.928722],[19.294195,41.92625],[19.284166,41.926277],[19.283278,41.925388],[19.279972,41.925415],[19.278305,41.924583],[19.272472,41.919582],[19.26825,41.919582],[19.267529,41.918751],[19.264999,41.918777],[19.264166,41.917915],[19.261639,41.917915],[19.260834,41.917057],[19.253334,41.916248],[19.252472,41.91711],[19.250778,41.917084],[19.249971,41.916248],[19.245832,41.916248],[19.242445,41.914612],[19.23914,41.914612],[19.236666,41.912918],[19.234556,41.911667],[19.235416,41.910831],[19.235445,41.907528],[19.237083,41.905834],[19.234972,41.904583],[19.234167,41.90625],[19.229555,41.91],[19.22961,41.910862],[19.225805,41.912056],[19.224167,41.91375],[19.220833,41.914555],[19.21911,41.916248],[19.216667,41.916248],[19.214083,41.917946],[19.212473,41.917915],[19.210833,41.919613],[19.20414,41.920418],[19.203777,41.922527],[19.203306,41.922916],[19.202473,41.922112],[19.200806,41.922085],[19.197472,41.92625],[19.196638,41.925446],[19.193361,41.925388],[19.190777,41.927055],[19.18664,41.927113],[19.185028,41.927944],[19.181639,41.931278],[19.176611,41.93211],[19.175444,41.933334],[19.176195,41.934166],[19.174139,41.936249],[19.173334,41.934639],[19.170805,41.934582],[19.167055,41.9375],[19.166639,41.938751],[19.163279,41.940472],[19.160833,41.940418],[19.16,41.942944],[19.155806,41.945446],[19.154972,41.947083],[19.152527,41.947109],[19.150806,41.947945],[19.14875,41.950027],[19.148695,41.952473],[19.147055,41.953304],[19.147028,41.954166],[19.152472,41.954582],[19.153334,41.953751],[19.159973,41.952084],[19.161667,41.951248],[19.163723,41.952499],[19.162083,41.955833],[19.158306,41.95961],[19.154972,41.960415],[19.151222,41.963333],[19.151251,41.964973],[19.149973,41.966278],[19.147444,41.966305],[19.145805,41.967918],[19.143305,41.96875],[19.13961,41.972527],[19.138695,41.975029],[19.137028,41.976696],[19.137056,41.978359],[19.140028,41.98214],[19.145834,41.982113],[19.146639,41.981277],[19.149166,41.981251],[19.149944,41.982918],[19.151251,41.983334],[19.151222,41.984196],[19.147499,41.988777],[19.139528,41.99086],[19.139944,41.992085],[19.14539,41.995029],[19.144527,41.995861],[19.144751,42],[19.146194,42.000751],[19.143278,42.002804],[19.142,42.00489],[19.144556,42.006554],[19.1495,42.013248],[19.148251,42.0145],[19.146639,42.014473],[19.144112,42.016998],[19.140333,42.017387],[19.140333,42.019917],[19.146139,42.023224],[19.147055,42.026611],[19.144972,42.026974],[19.140751,42.029472],[19.139055,42.029446],[19.137888,42.03075],[19.137833,42.032391],[19.140333,42.033249],[19.1395,42.035694],[19.140333,42.038223],[19.142,42.039055],[19.142,42.042362],[19.139944,42.044445],[19.133249,42.04697],[19.129084,42.05114],[19.126612,42.05114],[19.119139,42.056973],[19.115749,42.057777],[19.111973,42.060749],[19.111639,42.062],[19.109945,42.061974],[19.104111,42.064445],[19.101555,42.067833],[19.097473,42.068638],[19.094944,42.071167],[19.092472,42.07111],[19.091612,42.071972],[19.089083,42.071972],[19.085306,42.07489],[19.086195,42.076557],[19.084917,42.077805],[19.082472,42.077805],[19.078278,42.081112],[19.076584,42.082001],[19.074112,42.081974],[19.069529,42.089085],[19.070807,42.090305],[19.071583,42.089474],[19.074972,42.089474],[19.075361,42.091526],[19.076584,42.091946],[19.077833,42.090721],[19.077473,42.087776],[19.08239,42.087807],[19.08325,42.086971],[19.084167,42.087776],[19.086611,42.087833],[19.089472,42.08989],[19.092056,42.095749],[19.091167,42.099918],[19.088722,42.107361],[19.086195,42.109055],[19.085777,42.110306],[19.084944,42.110279],[19.08411,42.111973],[19.081638,42.112804],[19.077389,42.116165],[19.075777,42.116138],[19.069111,42.120304],[19.067444,42.122002],[19.062834,42.122391],[19.063667,42.12989],[19.061583,42.132832],[19.059111,42.13364],[19.055805,42.136082],[19.04911,42.136166],[19.048222,42.135277],[19.041611,42.135277],[19.03825,42.136944],[19.036583,42.136971],[19.035749,42.136082],[19.032389,42.135307],[19.029972,42.136971],[19.029499,42.134918],[19.02739,42.133667],[19.024889,42.139446],[19.019056,42.139473],[19.014084,42.13361],[19.011639,42.13361],[19.009472,42.138222],[19.006166,42.141529],[19.006166,42.144054],[19.003695,42.146526],[19.002806,42.149887],[19.005333,42.155693],[19,42.159443],[18.993279,42.158695],[18.990833,42.162888],[18.986639,42.162083],[18.985806,42.164585],[18.97661,42.167889],[18.974167,42.170361],[18.972473,42.170387],[18.970028,42.172085],[18.967945,42.174999],[18.96789,42.179111],[18.971277,42.183304],[18.970417,42.188332],[18.967501,42.19125],[18.965,42.192055],[18.961695,42.194557],[18.958279,42.195415],[18.957472,42.194557],[18.956667,42.195389],[18.95414,42.195415],[18.952055,42.197498],[18.950806,42.20039],[18.946667,42.200417],[18.943333,42.203724],[18.939972,42.205387],[18.939138,42.204582],[18.937445,42.204556],[18.936666,42.205387],[18.932501,42.205418],[18.931694,42.204556],[18.929972,42.205387],[18.927111,42.208305],[18.92625,42.210804],[18.924973,42.212029],[18.923277,42.212055],[18.922472,42.212917],[18.918333,42.212891],[18.915777,42.215416],[18.912527,42.216221],[18.907084,42.220806],[18.906221,42.223305],[18.907055,42.225777],[18.905445,42.228333],[18.905416,42.23164],[18.904167,42.233723],[18.899944,42.233723],[18.899584,42.235832],[18.897083,42.236694],[18.897028,42.238304],[18.898695,42.239113],[18.899529,42.241665],[18.896194,42.244972],[18.896223,42.248333],[18.897861,42.249973],[18.897055,42.251667],[18.894167,42.254528],[18.891251,42.255001],[18.891222,42.255806],[18.893694,42.257446],[18.892471,42.259609],[18.891222,42.259972],[18.892111,42.268333],[18.889584,42.27],[18.888306,42.27375],[18.885,42.27375],[18.884111,42.274529],[18.8825,42.274555],[18.881222,42.275806],[18.882084,42.277473],[18.879944,42.279556],[18.865862,42.279583],[18.862888,42.278332],[18.862499,42.276249],[18.860806,42.276222],[18.858723,42.278305],[18.858723,42.280804],[18.856611,42.282082],[18.856251,42.283333],[18.853306,42.283749],[18.852501,42.284584],[18.848362,42.284557],[18.847473,42.283695],[18.844999,42.283749],[18.843334,42.28286],[18.841194,42.279972],[18.840389,42.276638],[18.839167,42.276222],[18.838362,42.275391],[18.834167,42.276249],[18.831667,42.272861],[18.828278,42.272861],[18.825834,42.276249],[18.8225,42.277054],[18.817499,42.28125],[18.815805,42.281193],[18.813334,42.283722],[18.810806,42.283749],[18.803694,42.279945],[18.803778,42.2775],[18.805389,42.275806],[18.805389,42.273277],[18.804193,42.272057],[18.80164,42.274582],[18.79911,42.274529],[18.798306,42.275391],[18.796694,42.275417],[18.796249,42.276669],[18.794138,42.277889],[18.791611,42.277889],[18.788305,42.279583],[18.787083,42.275002],[18.787861,42.272499],[18.789528,42.270805],[18.78875,42.269138],[18.783306,42.266224],[18.78161,42.266251],[18.780806,42.267113],[18.777416,42.267082],[18.776638,42.26786],[18.775778,42.267918],[18.769945,42.27375],[18.769112,42.273724],[18.767471,42.276222],[18.763334,42.277916],[18.761639,42.280388],[18.759111,42.282055],[18.755833,42.282917],[18.754555,42.284138],[18.754583,42.285805],[18.751223,42.287445],[18.750444,42.290001],[18.749166,42.291248],[18.745806,42.292027],[18.74375,42.295834],[18.738306,42.299557],[18.737888,42.300804],[18.736666,42.302082],[18.735777,42.301224],[18.733305,42.301224],[18.732027,42.302502],[18.731667,42.304554],[18.729111,42.304554],[18.726667,42.306252],[18.724527,42.309971],[18.719555,42.313305],[18.71911,42.314556],[18.713306,42.317917],[18.710833,42.320389],[18.707056,42.322498],[18.710417,42.324944],[18.711666,42.327026],[18.713278,42.327084],[18.714167,42.326221],[18.713694,42.328278],[18.709583,42.333279],[18.70875,42.339169],[18.706583,42.341251],[18.704971,42.341251],[18.703333,42.342083],[18.700806,42.345417],[18.696667,42.34539],[18.695389,42.346611],[18.69536,42.34914],[18.691639,42.352085],[18.689138,42.35289],[18.687056,42.354973],[18.687056,42.356693],[18.688334,42.357918],[18.699972,42.356251],[18.70414,42.353779],[18.707056,42.354168],[18.704166,42.355362],[18.701279,42.358334],[18.700361,42.359974],[18.700361,42.364166],[18.696638,42.367054],[18.689583,42.369999],[18.688694,42.37336],[18.691223,42.375805],[18.685806,42.38039],[18.684973,42.38036],[18.685389,42.383305],[18.684111,42.384583],[18.682888,42.384167],[18.681667,42.382084],[18.6775,42.382057],[18.676611,42.382889],[18.674139,42.382889],[18.672501,42.38372],[18.669971,42.385387],[18.665806,42.385418],[18.665001,42.38625],[18.664194,42.385387],[18.661638,42.385387],[18.660833,42.384583],[18.657499,42.384556],[18.656639,42.382889],[18.653749,42.381611],[18.653749,42.375778],[18.656639,42.374584],[18.658722,42.372471],[18.656639,42.370419],[18.655027,42.370445],[18.653749,42.369167],[18.653723,42.365833],[18.655001,42.362888],[18.653334,42.362057],[18.65,42.36211],[18.646639,42.36375],[18.644945,42.363724],[18.643723,42.364944],[18.643723,42.367474],[18.641666,42.368752],[18.637501,42.368721],[18.636612,42.367889],[18.634167,42.369556],[18.632,42.369167],[18.632444,42.367916],[18.634583,42.366638],[18.634501,42.36414],[18.6325,42.362083],[18.630833,42.361252],[18.628305,42.361195],[18.62414,42.362888],[18.621611,42.362888],[18.618279,42.365391],[18.609167,42.363724],[18.609167,42.367889],[18.607445,42.367916],[18.606667,42.368752],[18.602501,42.368721],[18.601667,42.367916],[18.600389,42.369141],[18.600416,42.370861],[18.59664,42.37289],[18.590778,42.374611],[18.590416,42.378307],[18.591278,42.379971],[18.588333,42.38039],[18.587418,42.379555],[18.585806,42.379528],[18.583723,42.383305],[18.579195,42.387054],[18.575834,42.386223],[18.572889,42.388279],[18.570389,42.391666],[18.570444,42.394138],[18.571695,42.395416],[18.575027,42.395416],[18.576666,42.394554],[18.576221,42.395805],[18.57625,42.397499],[18.578722,42.399166],[18.578306,42.400417],[18.574972,42.400391],[18.574083,42.401249],[18.565805,42.402084],[18.565001,42.402863],[18.562471,42.402889],[18.560806,42.403694],[18.557056,42.406639],[18.556223,42.410805],[18.557501,42.411221],[18.557472,42.412029],[18.553305,42.412056],[18.5525,42.412888],[18.549944,42.412918],[18.54789,42.414165],[18.54789,42.416637],[18.545444,42.421665],[18.549166,42.425415],[18.555,42.426224],[18.557501,42.431252],[18.559111,42.431221],[18.559944,42.43211],[18.5625,42.432026],[18.563305,42.432919],[18.5725,42.432888],[18.573305,42.432026],[18.576611,42.432056],[18.58,42.430416],[18.584167,42.430389],[18.584972,42.429554],[18.5875,42.429585],[18.588306,42.428749],[18.596611,42.427891],[18.6,42.42625],[18.602472,42.426193],[18.605833,42.424557],[18.610001,42.424583],[18.610806,42.423752],[18.613277,42.423721],[18.615805,42.422085],[18.620028,42.421249],[18.625,42.417915],[18.627472,42.417915],[18.628277,42.417057],[18.632473,42.416248],[18.638361,42.413723],[18.642471,42.412888],[18.645805,42.410389],[18.649973,42.410362],[18.650778,42.409527],[18.658306,42.408779],[18.659166,42.407917],[18.661638,42.40786],[18.664194,42.406193],[18.666639,42.40625],[18.667444,42.405418],[18.67,42.405388],[18.670805,42.404556],[18.673277,42.404556],[18.674139,42.403778],[18.674973,42.40453],[18.687529,42.405418],[18.688305,42.404583],[18.689945,42.40461],[18.690805,42.403751],[18.694139,42.403721],[18.697472,42.401222],[18.700388,42.397499],[18.705,42.393749],[18.706694,42.393723],[18.7075,42.392887],[18.70875,42.394165],[18.709583,42.399166],[18.707083,42.401695],[18.708279,42.402916],[18.709972,42.402889],[18.710388,42.404167],[18.707445,42.404556],[18.707027,42.405804],[18.708305,42.406223],[18.709139,42.407055],[18.710028,42.406193],[18.712473,42.40625],[18.713751,42.407471],[18.713722,42.410805],[18.712917,42.41164],[18.713722,42.41497],[18.712473,42.417057],[18.709139,42.417915],[18.708778,42.419167],[18.7075,42.420387],[18.705805,42.420418],[18.700001,42.427055],[18.697445,42.427055],[18.695807,42.427891],[18.692862,42.43],[18.692055,42.433304],[18.689167,42.437916],[18.68375,42.438332],[18.687111,42.441666],[18.686222,42.442501],[18.685389,42.448307],[18.682888,42.451637],[18.68125,42.455776],[18.682888,42.464169],[18.685389,42.467472],[18.687027,42.474998],[18.689972,42.477055],[18.690805,42.477859],[18.693277,42.477917],[18.696638,42.476276],[18.701611,42.475418],[18.702417,42.474556],[18.704111,42.474583],[18.705,42.473751],[18.7125,42.473721],[18.714945,42.472057],[18.72164,42.471222],[18.728306,42.467861],[18.729973,42.467056],[18.734138,42.467083],[18.737499,42.463696],[18.740805,42.462055],[18.746611,42.457085],[18.748333,42.457054],[18.751194,42.45414],[18.752861,42.450806],[18.754194,42.450359],[18.755388,42.449139],[18.755417,42.444168],[18.757055,42.441612],[18.755388,42.438332],[18.756639,42.437889],[18.759611,42.434971],[18.761194,42.429165],[18.761278,42.427471],[18.760361,42.42664],[18.763334,42.423721],[18.76664,42.422085],[18.769583,42.423332],[18.767084,42.426666],[18.767,42.430832],[18.765388,42.434971],[18.762028,42.440807],[18.763779,42.448334],[18.765388,42.452473],[18.765333,42.458305],[18.76375,42.461639],[18.763779,42.467472],[18.762833,42.469971],[18.76375,42.470806],[18.76375,42.474972],[18.762861,42.475807],[18.762917,42.480835],[18.765388,42.485001],[18.765417,42.48661],[18.763721,42.488304],[18.762501,42.490391],[18.761694,42.489582],[18.754972,42.489555],[18.750805,42.487083],[18.744944,42.484554],[18.743305,42.484585],[18.7425,42.483696],[18.740028,42.483723],[18.73914,42.482887],[18.735806,42.482887],[18.734972,42.482082],[18.73336,42.482029],[18.729973,42.483749],[18.727501,42.483749],[18.72661,42.482887],[18.723278,42.482861],[18.7225,42.483723],[18.720806,42.482944],[18.709139,42.482861],[18.708361,42.483723],[18.700001,42.483723],[18.696611,42.485363],[18.691223,42.493332],[18.691223,42.50161],[18.69375,42.504971],[18.69375,42.506638],[18.695389,42.510777],[18.693333,42.513721],[18.691639,42.513748],[18.689112,42.515415],[18.68836,42.514584],[18.685806,42.514526],[18.683306,42.511223],[18.682444,42.511223],[18.679138,42.507027],[18.677917,42.506668],[18.677444,42.504581],[18.675777,42.503693],[18.669971,42.50375],[18.669167,42.502888],[18.665001,42.500389],[18.661638,42.499584],[18.65661,42.495419],[18.654139,42.495361],[18.651222,42.490776],[18.653305,42.488724],[18.658333,42.488724],[18.65914,42.487915],[18.665777,42.487888],[18.666666,42.487057],[18.669971,42.487057],[18.672527,42.48539],[18.6775,42.484585],[18.680805,42.482887],[18.684999,42.482056],[18.685806,42.481194],[18.6875,42.481224],[18.688723,42.479946],[18.688778,42.478359],[18.686251,42.475777],[18.68461,42.471638],[18.682444,42.469528],[18.679193,42.467918],[18.677029,42.465805],[18.677917,42.464973],[18.67786,42.459999],[18.676584,42.458721],[18.673306,42.457916],[18.669138,42.45536],[18.666666,42.455418],[18.665777,42.454556],[18.657499,42.448723],[18.651638,42.448776],[18.649918,42.447083],[18.644138,42.444557],[18.642445,42.442917],[18.640806,42.44289],[18.638334,42.441223],[18.634167,42.441193],[18.630777,42.438721],[18.628305,42.438751],[18.627501,42.437862],[18.624083,42.437916],[18.623362,42.437027],[18.619972,42.437084],[18.619139,42.436279],[18.613306,42.43539],[18.609972,42.433723],[18.599972,42.432888],[18.599167,42.433723],[18.595778,42.433723],[18.592445,42.436222],[18.585806,42.437916],[18.573334,42.447083],[18.567499,42.452057],[18.563334,42.452084],[18.559999,42.45039],[18.555861,42.447918],[18.553305,42.447918],[18.552473,42.447029],[18.550777,42.447056],[18.549973,42.447887],[18.545805,42.447918],[18.544916,42.448776],[18.541611,42.44875],[18.540806,42.447887],[18.535,42.447918],[18.534195,42.44875],[18.531639,42.448696],[18.529972,42.45039],[18.527472,42.451195],[18.526611,42.452888],[18.520779,42.456196],[18.51664,42.457085],[18.515833,42.456249],[18.512444,42.456249],[18.511694,42.455418],[18.51,42.455387],[18.50625,42.452446],[18.505388,42.450832],[18.506195,42.449974],[18.50625,42.446609],[18.507889,42.444195],[18.50835,42.443638],[18.512444,42.438751],[18.515028,42.437889],[18.519972,42.433693],[18.522444,42.431252],[18.525778,42.429527],[18.527472,42.429585],[18.528786,42.428294],[18.529124,42.427776],[18.530083,42.423766],[18.529996,42.423505],[18.529429,42.423451],[18.528434,42.423355],[18.5259,42.423113],[18.525333,42.421631],[18.524548,42.420585],[18.522544,42.42137]]],[[[19.363644,41.848729],[19.341732,41.86205],[19.339872,41.863402],[19.338351,41.864755],[19.338943,41.866276],[19.339785,41.866215],[19.339863,41.866539],[19.341393,41.867374],[19.344605,41.868896],[19.345265,41.869016],[19.347394,41.869403],[19.348356,41.869474],[19.358718,41.870248],[19.369282,41.872529],[19.373113,41.874525],[19.373695,41.874168],[19.373722,41.867474],[19.373419,41.864653],[19.373419,41.864652],[19.37266,41.861591],[19.370972,41.856895],[19.371057,41.855627],[19.371479,41.854444],[19.371648,41.853261],[19.371651,41.851926],[19.370527,41.848891],[19.369282,41.847514],[19.367268,41.846345],[19.365003,41.847903],[19.363644,41.848729]]],[[[18.936611,42.199554],[18.9375,42.198723],[18.938334,42.198723],[18.938723,42.196609],[18.937445,42.195389],[18.934973,42.195415],[18.934584,42.195862],[18.93461,42.197472],[18.936611,42.199554]]],[[[18.93786,42.191639],[18.936666,42.190418],[18.935806,42.19125],[18.934111,42.191223],[18.933722,42.191666],[18.934111,42.193722],[18.935806,42.193695],[18.93786,42.191639]]],[[[18.894972,42.249584],[18.893278,42.249554],[18.892944,42.25],[18.892889,42.251667],[18.893333,42.252056],[18.894945,42.252083],[18.895416,42.25164],[18.895416,42.249973],[18.894972,42.249584]]],[[[18.859583,42.260029],[18.858334,42.257946],[18.855806,42.260387],[18.853306,42.261223],[18.847055,42.268307],[18.847473,42.269554],[18.849167,42.269611],[18.856667,42.264584],[18.859583,42.260029]]],[[[18.846222,42.268333],[18.845028,42.267056],[18.843334,42.267082],[18.842945,42.267471],[18.84289,42.268333],[18.844999,42.27039],[18.845833,42.27039],[18.846222,42.269943],[18.846222,42.268333]]],[[[18.705833,42.404583],[18.702444,42.404556],[18.70211,42.405029],[18.702444,42.406223],[18.705862,42.40625],[18.706249,42.405777],[18.705833,42.404583]]],[[[18.703278,42.330418],[18.701666,42.330387],[18.699528,42.332474],[18.699972,42.334583],[18.701666,42.334557],[18.702888,42.333332],[18.702944,42.331665],[18.703751,42.330833],[18.703278,42.330418]]],[[[18.702,42.327473],[18.701639,42.327057],[18.699944,42.327084],[18.69875,42.328335],[18.700001,42.329556],[18.700777,42.329556],[18.702055,42.328335],[18.702,42.327473]]],[[[18.692499,42.412888],[18.694111,42.410416],[18.697527,42.410416],[18.700806,42.408779],[18.701221,42.408306],[18.699944,42.407082],[18.696638,42.407082],[18.695833,42.40786],[18.694944,42.407055],[18.693306,42.407082],[18.691639,42.408749],[18.688305,42.408749],[18.687445,42.409584],[18.683277,42.409557],[18.682945,42.41],[18.684111,42.412083],[18.689112,42.412083],[18.690027,42.412888],[18.692499,42.412888]]],[[[18.666611,42.365417],[18.665001,42.365391],[18.663723,42.366665],[18.664194,42.368752],[18.665806,42.368721],[18.667944,42.3675],[18.667889,42.366638],[18.666611,42.365417]]],[[[18.559139,42.397083],[18.560417,42.395805],[18.559999,42.394585],[18.557472,42.394527],[18.557056,42.394974],[18.557472,42.396252],[18.558306,42.396221],[18.559139,42.397083]]],[[[18.540806,42.40625],[18.540028,42.406223],[18.53875,42.407471],[18.538723,42.408306],[18.539972,42.409557],[18.540833,42.409557],[18.542028,42.408333],[18.542055,42.407471],[18.540806,42.40625]]]],"type":"MultiPolygon"}
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/2185

This PR updates the `edtf:inception` property value to a valid edtf string, based on the 'Interval' examples in the [EDTF spec doc](https://www.loc.gov/standards/datetime/).